### PR TITLE
Adding selectors to mainnet: bsquared, bitlayer, bob, sei

### DIFF
--- a/generated_chains.go
+++ b/generated_chains.go
@@ -22,6 +22,7 @@ var (
 	BITCICHAIN_MAINNET                             = Chain{EvmChainID: 1907, Selector: 4874388048629246000, Name: "bitcichain-mainnet"}
 	BITCICHAIN_TESTNET                             = Chain{EvmChainID: 1908, Selector: 4888058894222120000, Name: "bitcichain-testnet"}
 	BITCOIN_MAINNET_BITLAYER_1                     = Chain{EvmChainID: 200901, Selector: 7937294810946806131, Name: "bitcoin-mainnet-bitlayer-1"}
+	BITCOIN_MAINNET_BOB_1                          = Chain{EvmChainID: 60808, Selector: 3849287863852499584, Name: "bitcoin-mainnet-bob-1"}
 	BITCOIN_MAINNET_BOTANIX                        = Chain{EvmChainID: 3637, Selector: 4560701533377838164, Name: "bitcoin-mainnet-botanix"}
 	BITCOIN_MAINNET_BSQUARED_1                     = Chain{EvmChainID: 223, Selector: 5406759801798337480, Name: "bitcoin-mainnet-bsquared-1"}
 	BITCOIN_MERLIN_MAINNET                         = Chain{EvmChainID: 4200, Selector: 241851231317828981, Name: "bitcoin-merlin-mainnet"}
@@ -30,6 +31,7 @@ var (
 	BITCOIN_TESTNET_BSQUARED_1                     = Chain{EvmChainID: 1123, Selector: 1948510578179542068, Name: "bitcoin-testnet-bsquared-1"}
 	BITCOIN_TESTNET_MERLIN                         = Chain{EvmChainID: 686868, Selector: 5269261765892944301, Name: "bitcoin-testnet-merlin"}
 	BITCOIN_TESTNET_ROOTSTOCK                      = Chain{EvmChainID: 31, Selector: 8953668971247136127, Name: "bitcoin-testnet-rootstock"}
+	BITCOIN_TESTNET_SEPOLIA_BOB_1                  = Chain{EvmChainID: 808813, Selector: 5535534526963509396, Name: "bitcoin-testnet-sepolia-bob-1"}
 	BITTORRENT_CHAIN_MAINNET                       = Chain{EvmChainID: 199, Selector: 3776006016387883143, Name: "bittorrent_chain-mainnet"}
 	BITTORRENT_CHAIN_TESTNET                       = Chain{EvmChainID: 1029, Selector: 4459371029167934217, Name: "bittorrent_chain-testnet"}
 	CELO_MAINNET                                   = Chain{EvmChainID: 42220, Selector: 1346049177634351622, Name: "celo-mainnet"}
@@ -46,7 +48,6 @@ var (
 	ETHEREUM_MAINNET_ASTAR_ZKEVM_1                 = Chain{EvmChainID: 3776, Selector: 1540201334317828111, Name: "ethereum-mainnet-astar-zkevm-1"}
 	ETHEREUM_MAINNET_BASE_1                        = Chain{EvmChainID: 8453, Selector: 15971525489660198786, Name: "ethereum-mainnet-base-1"}
 	ETHEREUM_MAINNET_BLAST_1                       = Chain{EvmChainID: 81457, Selector: 4411394078118774322, Name: "ethereum-mainnet-blast-1"}
-	ETHEREUM_MAINNET_BOB_1                         = Chain{EvmChainID: 60808, Selector: 3849287863852499584, Name: "ethereum-mainnet-bob-1"}
 	ETHEREUM_MAINNET_IMMUTABLE_ZKEVM_1             = Chain{EvmChainID: 13371, Selector: 1237925231416731909, Name: "ethereum-mainnet-immutable-zkevm-1"}
 	ETHEREUM_MAINNET_KROMA_1                       = Chain{EvmChainID: 255, Selector: 3719320017875267166, Name: "ethereum-mainnet-kroma-1"}
 	ETHEREUM_MAINNET_LINEA_1                       = Chain{EvmChainID: 59144, Selector: 4627098889531055414, Name: "ethereum-mainnet-linea-1"}
@@ -74,7 +75,6 @@ var (
 	ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1_TREASURE_1 = Chain{EvmChainID: 978657, Selector: 10443705513486043421, Name: "ethereum-testnet-sepolia-arbitrum-1-treasure-1"}
 	ETHEREUM_TESTNET_SEPOLIA_BASE_1                = Chain{EvmChainID: 84532, Selector: 10344971235874465080, Name: "ethereum-testnet-sepolia-base-1"}
 	ETHEREUM_TESTNET_SEPOLIA_BLAST_1               = Chain{EvmChainID: 168587773, Selector: 2027362563942762617, Name: "ethereum-testnet-sepolia-blast-1"}
-	ETHEREUM_TESTNET_SEPOLIA_BOB_1                 = Chain{EvmChainID: 808813, Selector: 5535534526963509396, Name: "ethereum-testnet-sepolia-bob-1"}
 	ETHEREUM_TESTNET_SEPOLIA_CORN_1                = Chain{EvmChainID: 21000000, Selector: 1467427327723633929, Name: "ethereum-testnet-sepolia-corn-1"}
 	ETHEREUM_TESTNET_SEPOLIA_IMMUTABLE_ZKEVM_1     = Chain{EvmChainID: 13473, Selector: 4526165231216331901, Name: "ethereum-testnet-sepolia-immutable-zkevm-1"}
 	ETHEREUM_TESTNET_SEPOLIA_KROMA_1               = Chain{EvmChainID: 2358, Selector: 5990477251245693094, Name: "ethereum-testnet-sepolia-kroma-1"}
@@ -256,6 +256,7 @@ var ALL = []Chain{
 	BITCICHAIN_MAINNET,
 	BITCICHAIN_TESTNET,
 	BITCOIN_MAINNET_BITLAYER_1,
+	BITCOIN_MAINNET_BOB_1,
 	BITCOIN_MAINNET_BOTANIX,
 	BITCOIN_MAINNET_BSQUARED_1,
 	BITCOIN_MERLIN_MAINNET,
@@ -264,6 +265,7 @@ var ALL = []Chain{
 	BITCOIN_TESTNET_BSQUARED_1,
 	BITCOIN_TESTNET_MERLIN,
 	BITCOIN_TESTNET_ROOTSTOCK,
+	BITCOIN_TESTNET_SEPOLIA_BOB_1,
 	BITTORRENT_CHAIN_MAINNET,
 	BITTORRENT_CHAIN_TESTNET,
 	CELO_MAINNET,
@@ -280,7 +282,6 @@ var ALL = []Chain{
 	ETHEREUM_MAINNET_ASTAR_ZKEVM_1,
 	ETHEREUM_MAINNET_BASE_1,
 	ETHEREUM_MAINNET_BLAST_1,
-	ETHEREUM_MAINNET_BOB_1,
 	ETHEREUM_MAINNET_IMMUTABLE_ZKEVM_1,
 	ETHEREUM_MAINNET_KROMA_1,
 	ETHEREUM_MAINNET_LINEA_1,
@@ -308,7 +309,6 @@ var ALL = []Chain{
 	ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1_TREASURE_1,
 	ETHEREUM_TESTNET_SEPOLIA_BASE_1,
 	ETHEREUM_TESTNET_SEPOLIA_BLAST_1,
-	ETHEREUM_TESTNET_SEPOLIA_BOB_1,
 	ETHEREUM_TESTNET_SEPOLIA_CORN_1,
 	ETHEREUM_TESTNET_SEPOLIA_IMMUTABLE_ZKEVM_1,
 	ETHEREUM_TESTNET_SEPOLIA_KROMA_1,

--- a/generated_chains.go
+++ b/generated_chains.go
@@ -17,6 +17,7 @@ var (
 	AVALANCHE_TESTNET_FUJI                         = Chain{EvmChainID: 43113, Selector: 14767482510784806043, Name: "avalanche-testnet-fuji"}
 	AVALANCHE_TESTNET_NEXON                        = Chain{EvmChainID: 595581, Selector: 7837562506228496256, Name: "avalanche-testnet-nexon"}
 	BERACHAIN_TESTNET_ARTIO                        = Chain{EvmChainID: 80085, Selector: 12336603543561911511, Name: "berachain-testnet-artio"}
+	BERACHAIN_TESTNET_BARTIO                       = Chain{EvmChainID: 80084, Selector: 8999465244383784164, Name: "berachain-testnet-bartio"}
 	BINANCE_SMART_CHAIN_MAINNET                    = Chain{EvmChainID: 56, Selector: 11344663589394136015, Name: "binance_smart_chain-mainnet"}
 	BINANCE_SMART_CHAIN_TESTNET                    = Chain{EvmChainID: 97, Selector: 13264668187771770619, Name: "binance_smart_chain-testnet"}
 	BITCICHAIN_MAINNET                             = Chain{EvmChainID: 1907, Selector: 4874388048629246000, Name: "bitcichain-mainnet"}
@@ -251,6 +252,7 @@ var ALL = []Chain{
 	AVALANCHE_TESTNET_FUJI,
 	AVALANCHE_TESTNET_NEXON,
 	BERACHAIN_TESTNET_ARTIO,
+	BERACHAIN_TESTNET_BARTIO,
 	BINANCE_SMART_CHAIN_MAINNET,
 	BINANCE_SMART_CHAIN_TESTNET,
 	BITCICHAIN_MAINNET,

--- a/generated_chains.go
+++ b/generated_chains.go
@@ -21,7 +21,9 @@ var (
 	BINANCE_SMART_CHAIN_TESTNET                    = Chain{EvmChainID: 97, Selector: 13264668187771770619, Name: "binance_smart_chain-testnet"}
 	BITCICHAIN_MAINNET                             = Chain{EvmChainID: 1907, Selector: 4874388048629246000, Name: "bitcichain-mainnet"}
 	BITCICHAIN_TESTNET                             = Chain{EvmChainID: 1908, Selector: 4888058894222120000, Name: "bitcichain-testnet"}
+	BITCOIN_MAINNET_BITLAYER_1                     = Chain{EvmChainID: 200901, Selector: 7937294810946806131, Name: "bitcoin-mainnet-bitlayer-1"}
 	BITCOIN_MAINNET_BOTANIX                        = Chain{EvmChainID: 3637, Selector: 4560701533377838164, Name: "bitcoin-mainnet-botanix"}
+	BITCOIN_MAINNET_BSQUARED_1                     = Chain{EvmChainID: 223, Selector: 5406759801798337480, Name: "bitcoin-mainnet-bsquared-1"}
 	BITCOIN_MERLIN_MAINNET                         = Chain{EvmChainID: 4200, Selector: 241851231317828981, Name: "bitcoin-merlin-mainnet"}
 	BITCOIN_TESTNET_BITLAYER_1                     = Chain{EvmChainID: 200810, Selector: 3789623672476206327, Name: "bitcoin-testnet-bitlayer-1"}
 	BITCOIN_TESTNET_BOTANIX                        = Chain{EvmChainID: 3636, Selector: 1467223411771711614, Name: "bitcoin-testnet-botanix"}
@@ -53,6 +55,7 @@ var (
 	ETHEREUM_MAINNET_OPTIMISM_1                    = Chain{EvmChainID: 10, Selector: 3734403246176062136, Name: "ethereum-mainnet-optimism-1"}
 	ETHEREUM_MAINNET_POLYGON_ZKEVM_1               = Chain{EvmChainID: 1101, Selector: 4348158687435793198, Name: "ethereum-mainnet-polygon-zkevm-1"}
 	ETHEREUM_MAINNET_SCROLL_1                      = Chain{EvmChainID: 534352, Selector: 13204309965629103672, Name: "ethereum-mainnet-scroll-1"}
+	ETHEREUM_MAINNET_SEPOLIA_BOB_1                 = Chain{EvmChainID: 60808, Selector: 3849287863852499584, Name: "ethereum-mainnet-sepolia-bob-1"}
 	ETHEREUM_MAINNET_XLAYER_1                      = Chain{EvmChainID: 196, Selector: 3016212468291539606, Name: "ethereum-mainnet-xlayer-1"}
 	ETHEREUM_MAINNET_ZIRCUIT_1                     = Chain{EvmChainID: 48900, Selector: 17198166215261833993, Name: "ethereum-mainnet-zircuit-1"}
 	ETHEREUM_MAINNET_ZKSYNC_1                      = Chain{EvmChainID: 324, Selector: 1562403441176082196, Name: "ethereum-mainnet-zksync-1"}
@@ -123,6 +126,7 @@ var (
 	PRIVATE_TESTNET_MICA                           = Chain{EvmChainID: 424242, Selector: 4489326297382772450, Name: "private-testnet-mica"}
 	PRIVATE_TESTNET_OPALA                          = Chain{EvmChainID: 45439, Selector: 8446413392851542429, Name: "private-testnet-opala"}
 	RONIN_TESTNET_SAIGON                           = Chain{EvmChainID: 2021, Selector: 13116810400804392105, Name: "ronin-testnet-saigon"}
+	SEI_MAINNET_PACIFIC                            = Chain{EvmChainID: 1329, Selector: 9027416829622342829, Name: "sei-mainnet-pacific"}
 	SEI_TESTNET_ATLANTIC                           = Chain{EvmChainID: 1328, Selector: 1216300075444106652, Name: "sei-testnet-atlantic"}
 	SONIC_TESTNET                                  = Chain{EvmChainID: 64165, Selector: 3676871237479449268, Name: "sonic-testnet"}
 	STORY_TESTNET                                  = Chain{EvmChainID: 1513, Selector: 4237030917318060427, Name: "story-testnet"}
@@ -251,7 +255,9 @@ var ALL = []Chain{
 	BINANCE_SMART_CHAIN_TESTNET,
 	BITCICHAIN_MAINNET,
 	BITCICHAIN_TESTNET,
+	BITCOIN_MAINNET_BITLAYER_1,
 	BITCOIN_MAINNET_BOTANIX,
+	BITCOIN_MAINNET_BSQUARED_1,
 	BITCOIN_MERLIN_MAINNET,
 	BITCOIN_TESTNET_BITLAYER_1,
 	BITCOIN_TESTNET_BOTANIX,
@@ -283,6 +289,7 @@ var ALL = []Chain{
 	ETHEREUM_MAINNET_OPTIMISM_1,
 	ETHEREUM_MAINNET_POLYGON_ZKEVM_1,
 	ETHEREUM_MAINNET_SCROLL_1,
+	ETHEREUM_MAINNET_SEPOLIA_BOB_1,
 	ETHEREUM_MAINNET_XLAYER_1,
 	ETHEREUM_MAINNET_ZIRCUIT_1,
 	ETHEREUM_MAINNET_ZKSYNC_1,
@@ -353,6 +360,7 @@ var ALL = []Chain{
 	PRIVATE_TESTNET_MICA,
 	PRIVATE_TESTNET_OPALA,
 	RONIN_TESTNET_SAIGON,
+	SEI_MAINNET_PACIFIC,
 	SEI_TESTNET_ATLANTIC,
 	SONIC_TESTNET,
 	STORY_TESTNET,

--- a/generated_chains.go
+++ b/generated_chains.go
@@ -46,6 +46,7 @@ var (
 	ETHEREUM_MAINNET_ASTAR_ZKEVM_1                 = Chain{EvmChainID: 3776, Selector: 1540201334317828111, Name: "ethereum-mainnet-astar-zkevm-1"}
 	ETHEREUM_MAINNET_BASE_1                        = Chain{EvmChainID: 8453, Selector: 15971525489660198786, Name: "ethereum-mainnet-base-1"}
 	ETHEREUM_MAINNET_BLAST_1                       = Chain{EvmChainID: 81457, Selector: 4411394078118774322, Name: "ethereum-mainnet-blast-1"}
+	ETHEREUM_MAINNET_BOB_1                         = Chain{EvmChainID: 60808, Selector: 3849287863852499584, Name: "ethereum-mainnet-bob-1"}
 	ETHEREUM_MAINNET_IMMUTABLE_ZKEVM_1             = Chain{EvmChainID: 13371, Selector: 1237925231416731909, Name: "ethereum-mainnet-immutable-zkevm-1"}
 	ETHEREUM_MAINNET_KROMA_1                       = Chain{EvmChainID: 255, Selector: 3719320017875267166, Name: "ethereum-mainnet-kroma-1"}
 	ETHEREUM_MAINNET_LINEA_1                       = Chain{EvmChainID: 59144, Selector: 4627098889531055414, Name: "ethereum-mainnet-linea-1"}
@@ -55,7 +56,6 @@ var (
 	ETHEREUM_MAINNET_OPTIMISM_1                    = Chain{EvmChainID: 10, Selector: 3734403246176062136, Name: "ethereum-mainnet-optimism-1"}
 	ETHEREUM_MAINNET_POLYGON_ZKEVM_1               = Chain{EvmChainID: 1101, Selector: 4348158687435793198, Name: "ethereum-mainnet-polygon-zkevm-1"}
 	ETHEREUM_MAINNET_SCROLL_1                      = Chain{EvmChainID: 534352, Selector: 13204309965629103672, Name: "ethereum-mainnet-scroll-1"}
-	ETHEREUM_MAINNET_SEPOLIA_BOB_1                 = Chain{EvmChainID: 60808, Selector: 3849287863852499584, Name: "ethereum-mainnet-sepolia-bob-1"}
 	ETHEREUM_MAINNET_XLAYER_1                      = Chain{EvmChainID: 196, Selector: 3016212468291539606, Name: "ethereum-mainnet-xlayer-1"}
 	ETHEREUM_MAINNET_ZIRCUIT_1                     = Chain{EvmChainID: 48900, Selector: 17198166215261833993, Name: "ethereum-mainnet-zircuit-1"}
 	ETHEREUM_MAINNET_ZKSYNC_1                      = Chain{EvmChainID: 324, Selector: 1562403441176082196, Name: "ethereum-mainnet-zksync-1"}
@@ -126,7 +126,7 @@ var (
 	PRIVATE_TESTNET_MICA                           = Chain{EvmChainID: 424242, Selector: 4489326297382772450, Name: "private-testnet-mica"}
 	PRIVATE_TESTNET_OPALA                          = Chain{EvmChainID: 45439, Selector: 8446413392851542429, Name: "private-testnet-opala"}
 	RONIN_TESTNET_SAIGON                           = Chain{EvmChainID: 2021, Selector: 13116810400804392105, Name: "ronin-testnet-saigon"}
-	SEI_MAINNET_PACIFIC                            = Chain{EvmChainID: 1329, Selector: 9027416829622342829, Name: "sei-mainnet-pacific"}
+	SEI_MAINNET                                    = Chain{EvmChainID: 1329, Selector: 9027416829622342829, Name: "sei-mainnet"}
 	SEI_TESTNET_ATLANTIC                           = Chain{EvmChainID: 1328, Selector: 1216300075444106652, Name: "sei-testnet-atlantic"}
 	SONIC_TESTNET                                  = Chain{EvmChainID: 64165, Selector: 3676871237479449268, Name: "sonic-testnet"}
 	STORY_TESTNET                                  = Chain{EvmChainID: 1513, Selector: 4237030917318060427, Name: "story-testnet"}
@@ -280,6 +280,7 @@ var ALL = []Chain{
 	ETHEREUM_MAINNET_ASTAR_ZKEVM_1,
 	ETHEREUM_MAINNET_BASE_1,
 	ETHEREUM_MAINNET_BLAST_1,
+	ETHEREUM_MAINNET_BOB_1,
 	ETHEREUM_MAINNET_IMMUTABLE_ZKEVM_1,
 	ETHEREUM_MAINNET_KROMA_1,
 	ETHEREUM_MAINNET_LINEA_1,
@@ -289,7 +290,6 @@ var ALL = []Chain{
 	ETHEREUM_MAINNET_OPTIMISM_1,
 	ETHEREUM_MAINNET_POLYGON_ZKEVM_1,
 	ETHEREUM_MAINNET_SCROLL_1,
-	ETHEREUM_MAINNET_SEPOLIA_BOB_1,
 	ETHEREUM_MAINNET_XLAYER_1,
 	ETHEREUM_MAINNET_ZIRCUIT_1,
 	ETHEREUM_MAINNET_ZKSYNC_1,
@@ -360,7 +360,7 @@ var ALL = []Chain{
 	PRIVATE_TESTNET_MICA,
 	PRIVATE_TESTNET_OPALA,
 	RONIN_TESTNET_SAIGON,
-	SEI_MAINNET_PACIFIC,
+	SEI_MAINNET,
 	SEI_TESTNET_ATLANTIC,
 	SONIC_TESTNET,
 	STORY_TESTNET,

--- a/selector_families.yml
+++ b/selector_families.yml
@@ -559,7 +559,7 @@ selector_families:
     name: "bitcoin-testnet-bitlayer-1"
   5535534526963509396:
     family: evm
-    name: "ethereum-testnet-sepolia-bob-1"
+    name: "bitcoin-testnet-sepolia-bob-1"
   6827576821754315911:
     family: evm
     name: "ethereum-testnet-sepolia-lens-1"
@@ -583,7 +583,7 @@ selector_families:
     name: "bitcoin-mainnet-bitlayer-1"
   3849287863852499584:
     family: evm
-    name: "ethereum-mainnet-bob-1"
+    name: "bitcoin-mainnet-bob-1"
   9027416829622342829:
     family: evm
     name: "sei-mainnet"

--- a/selector_families.yml
+++ b/selector_families.yml
@@ -575,3 +575,15 @@ selector_families:
   4237030917318060427:
     family: evm
     name: "story-testnet"
+  5406759801798337480:
+    family: evm
+    name: "bitcoin-mainnet-bsquared-1"
+  7937294810946806131:
+    family: evm
+    name: "bitcoin-mainnet-bitlayer-1"
+  3849287863852499584:
+    family: evm
+    name: "ethereum-mainnet-sepolia-bob-1"
+  9027416829622342829:
+    family: evm
+    name: "sei-mainnet-pacific"

--- a/selector_families.yml
+++ b/selector_families.yml
@@ -450,6 +450,9 @@ selector_families:
   12336603543561911511:
     family: evm
     name: berachain-testnet-artio
+  8999465244383784164:
+    family: evm
+    name: berachain-testnet-bartio
   12470167056735102403:
     family: evm
   12499149790922928210:

--- a/selector_families.yml
+++ b/selector_families.yml
@@ -583,7 +583,7 @@ selector_families:
     name: "bitcoin-mainnet-bitlayer-1"
   3849287863852499584:
     family: evm
-    name: "ethereum-mainnet-sepolia-bob-1"
+    name: "ethereum-mainnet-bob-1"
   9027416829622342829:
     family: evm
-    name: "sei-mainnet-pacific"
+    name: "sei-mainnet"

--- a/selectors.yml
+++ b/selectors.yml
@@ -374,3 +374,15 @@ selectors:
   48900:
     selector: 17198166215261833993
     name: "ethereum-mainnet-zircuit-1"
+  223:
+    selector: 5406759801798337480
+    name: "bitcoin-mainnet-bsquared-1"
+  200901:
+    selector: 7937294810946806131
+    name: "bitcoin-mainnet-bitlayer-1"
+  60808:
+    selector: 3849287863852499584
+    name: "ethereum-mainnet-sepolia-bob-1"
+  1329:
+    selector: 9027416829622342829
+    name: "sei-mainnet-pacific"

--- a/selectors.yml
+++ b/selectors.yml
@@ -212,7 +212,7 @@ selectors:
     name: "bitcoin-testnet-bitlayer-1"
   808813:
     selector: 5535534526963509396
-    name: "ethereum-testnet-sepolia-bob-1"
+    name: "bitcoin-testnet-sepolia-bob-1"
   37111:
     selector: 6827576821754315911
     name: "ethereum-testnet-sepolia-lens-1"
@@ -382,7 +382,7 @@ selectors:
     name: "bitcoin-mainnet-bitlayer-1"
   60808:
     selector: 3849287863852499584
-    name: "ethereum-mainnet-bob-1"
+    name: "bitcoin-mainnet-bob-1"
   1329:
     selector: 9027416829622342829
     name: "sei-mainnet"

--- a/selectors.yml
+++ b/selectors.yml
@@ -150,6 +150,9 @@ selectors:
   80085:
     selector: 12336603543561911511
     name: "berachain-testnet-artio"
+  80084:
+    selector: 8999465244383784164
+    name: "berachain-testnet-bartio"
   84531:
     selector: 5790810961207155433
     name: "ethereum-testnet-goerli-base-1"

--- a/selectors.yml
+++ b/selectors.yml
@@ -382,7 +382,7 @@ selectors:
     name: "bitcoin-mainnet-bitlayer-1"
   60808:
     selector: 3849287863852499584
-    name: "ethereum-mainnet-sepolia-bob-1"
+    name: "ethereum-mainnet-bob-1"
   1329:
     selector: 9027416829622342829
-    name: "sei-mainnet-pacific"
+    name: "sei-mainnet"


### PR DESCRIPTION
The rest of the chains described here https://github.com/smartcontractkit/chain-selectors/pull/57 that are not in this PR (sonic, hyperliquid and story) is because they don't have mainnet yet.