### PR TITLE
Add BIX to codeowner to reduce dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*           @smartcontractkit/ccip
+* @smartcontractkit/ccip @smartcontractkit/bix-ship


### PR DESCRIPTION
Members of BIX SHIP team have developed good understanding of chain naming scheme.

BIX SHIP team is adding chain selectors a lot more frequently nowadays as they prioritize for agility, to reduce delays caused by cross-team comms, BIX should be able to review too. 