### PR TITLE
Transfers ownership of chain-selectors to BIX-Ship

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*           @smartcontractkit/ccip
+*           @smartcontractkit/bix-ship


### PR DESCRIPTION
This PR transfers ownership of the chain-selectors repo to BIX-Ship team. 
