### PR TITLE
Tag evm only get selector as deprecated

### DIFF
--- a/evm.go
+++ b/evm.go
@@ -69,6 +69,7 @@ func EvmChainIdToChainSelector() map[uint64]uint64 {
 	return copyMap
 }
 
+// Deprecated, this only supports EVM chains, use the chain agnostic `GetChainIDFromSelector` instead
 func ChainIdFromSelector(chainSelectorId uint64) (uint64, error) {
 	for k, v := range evmChainIdToChainSelector {
 		if v.ChainSelector == chainSelectorId {

--- a/evm.go
+++ b/evm.go
@@ -79,6 +79,7 @@ func ChainIdFromSelector(chainSelectorId uint64) (uint64, error) {
 	return 0, fmt.Errorf("chain not found for chain selector %d", chainSelectorId)
 }
 
+// Deprecated, this only supports EVM chains, use the chain agnostic `GetChainDetailsByChainIDAndFamily` instead
 func SelectorFromChainId(chainId uint64) (uint64, error) {
 	if chainSelectorId, exist := evmChainIdToChainSelector[chainId]; exist {
 		return chainSelectorId.ChainSelector, nil
@@ -86,6 +87,7 @@ func SelectorFromChainId(chainId uint64) (uint64, error) {
 	return 0, fmt.Errorf("chain selector not found for chain %d", chainId)
 }
 
+// Deprecated, this only supports EVM chains, use the chain agnostic `NameFromChainId` instead
 func NameFromChainId(chainId uint64) (string, error) {
 	details, exist := evmChainIdToChainSelector[chainId]
 	if !exist {


### PR DESCRIPTION
Tag the `ChainIdFromSelector` method as deprecated since it only supports evm chains, and we are expanding support to non evm.

If needed, people can still use it and we don't immediately need to migrate away from it.

If someone needs to also validate that a given chain is evm, they can also use the `GetSelectorFamily` with the same selector.