### PR TITLE
feat: add selector immutability checks

### DIFF
--- a/.github/workflows/immutability-check.yml
+++ b/.github/workflows/immutability-check.yml
@@ -1,0 +1,55 @@
+# In order to prevent accidental changes to selectors, we're ensuring their immutability
+# This action will fail if the immutability is violated
+name: Ensure Selector Immutability
+
+on: [ pull_request ]
+
+jobs:
+  immutability-check:
+    name: Check Selector Immutability
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout Changes
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout Previous Ref
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.before }}
+          path: old
+      - name: Extract Immutability Violations
+        id: immutability-check
+        uses: mikefarah/yq@bc5b54cb1d1f720db16c9f75c5b45384d00e5cbf # v4.44.5
+        with:
+          # This check will fail if any selector that is present in the previous ref has been modified in the current ref
+          cmd: yq e '.selectors as $old | load("selectors.yml") | .selectors as $new | $new | with_entries(select(.key as $key | $old | has($key))) | with_entries(select(.key as $key | $old[$key].selector != $new[$key].selector))' old/selectors.yml
+
+      - name: Check Immutability Violations
+        id: check-violations
+        run: |
+          violations=$(echo '${{ steps.immutability-check.outputs.result }}')
+          
+          if [[ ! $violations == "{}" ]]; then
+            echo "Selector immutability has been violated. Please ensure that exisiting selectors are not modified."
+            exit 1
+          fi
+
+      - name: Create comment
+        if: failure()
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ❌ Selector Immutability has been violated.
+            Please ensure that exisiting selectors are not modified or removed.
+
+            ```yaml
+            ${{ steps.immutability-check.outputs.result }}
+            ```
+          reactions: '+1'
+
+
+# Key removal check
+# yq e '.selectors as $old | load("new.yml").selectors as $new | $old | with_entries(select(.key as $key | $new | has($key) == false))' old.yml

--- a/.github/workflows/immutability-check.yml
+++ b/.github/workflows/immutability-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout Previous Ref
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.before }}
+          ref: ${{ github.event.pull_request.base.ref }}
           path: old
       - name: Extract Immutability Violations
         id: immutability-check

--- a/.github/workflows/immutability-check.yml
+++ b/.github/workflows/immutability-check.yml
@@ -61,6 +61,6 @@ jobs:
             Existing `chain-selectors` are immutable. Please ensure you have not modified or removed an existing selector
 
             ```yaml
-            ${{ steps.immutability-check.outputs.result || steps.removed-selectors-check.outputs.result }}
+            ${{ (steps.immutability-check.outputs.result != '{}') && steps.immutability-check.outputs.result || steps.removed-selectors-check.outputs.result }}
             ```
           reactions: '+1'

--- a/.github/workflows/immutability-check.yml
+++ b/.github/workflows/immutability-check.yml
@@ -19,20 +19,34 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: old
+
       - name: Extract Immutability Violations
         id: immutability-check
         uses: mikefarah/yq@bc5b54cb1d1f720db16c9f75c5b45384d00e5cbf # v4.44.5
         with:
-          # This check will fail if any selector that is present in the previous ref has been modified in the current ref
+          # Checks if any selector that is present in the previous ref has been modified in the current ref
           cmd: yq e '.selectors as $old | load("selectors.yml") | .selectors as $new | $new | with_entries(select(.key as $key | $old | has($key))) | with_entries(select(.key as $key | $old[$key].selector != $new[$key].selector))' old/selectors.yml
+
+      - name: Extract Removed Selectors
+        id: removed-selectors-check
+        uses: mikefarah/yq@bc5b54cb1d1f720db16c9f75c5b45384d00e5cbf # v4.44.5
+        with:
+          # Checks if any selector that previously existed has been removed
+          cmd: yq e '.selectors as $old | load("selectors.yml").selectors as $new | $old | with_entries(select(.key as $key | $new | has($key) == false))' old/selectors.yml
 
       - name: Check Immutability Violations
         id: check-violations
         run: |
           violations=$(echo '${{ steps.immutability-check.outputs.result }}')
+          removed=$(echo '${{ steps.removed-selectors-check.outputs.result }}')
           
           if [[ ! $violations == "{}" ]]; then
             echo "Selector immutability has been violated. Please ensure that exisiting selectors are not modified."
+            exit 1
+          fi
+
+          if [[ ! $removed == "{}" ]]; then
+            echo "Selector immutability has been violated. Please ensure that exisiting selectors are not removed."
             exit 1
           fi
 
@@ -42,14 +56,11 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ❌ Selector Immutability has been violated.
-            Please ensure that exisiting selectors are not modified or removed.
+            **Selector Immutability has been violated  ❌**
+
+            Existing `chain-selectors` are immutable. Please ensure you have not modified or removed an existing selector
 
             ```yaml
-            ${{ steps.immutability-check.outputs.result }}
+            ${{ steps.immutability-check.outputs.result || steps.removed-selectors-check.outputs.result }}
             ```
           reactions: '+1'
-
-
-# Key removal check
-# yq e '.selectors as $old | load("new.yml").selectors as $new | $old | with_entries(select(.key as $key | $new | has($key) == false))' old.yml

--- a/selectors.yml
+++ b/selectors.yml
@@ -4,7 +4,7 @@
 selectors:
   # Testnets
   31:
-    selector: 8953668971247136128
+    selector: 8953668971247136127
     name: "bitcoin-testnet-rootstock"
   41:
     selector: 729797994450396300
@@ -230,9 +230,6 @@ selectors:
   1328:
     selector: 1216300075444106652
     name: "sei-testnet-atlantic"
-  57054:
-    selector: 3676871237479449268
-    name: "sonic-testnet-blaze"
   998:
     selector: 4286062357653186312
     name: "hyperliquid-testnet"

--- a/selectors.yml
+++ b/selectors.yml
@@ -4,7 +4,7 @@
 selectors:
   # Testnets
   31:
-    selector: 8953668971247136127
+    selector: 8953668971247136128
     name: "bitcoin-testnet-rootstock"
   41:
     selector: 729797994450396300
@@ -29,7 +29,7 @@ selectors:
     name: "velas-testnet"
   195:
     selector: 2066098519157881736
-    name: "ethereum-testnet-sepolia-xlayer-1"  
+    name: "ethereum-testnet-sepolia-xlayer-1"
   280:
     selector: 6802309497652714138
     name: "ethereum-testnet-goerli-zksync-1"
@@ -257,7 +257,6 @@ selectors:
   4801:
     selector: 5299555114858065850
     name: "ethereum-testnet-sepolia-worldchain-1"
- 
 
   # Mainnets
   1:
@@ -425,7 +424,7 @@ selectors:
   1329:
     selector: 9027416829622342829
     name: "sei-mainnet"
-  2020: 
+  2020:
     selector: 6916147374840168594
     name: "ronin-mainnet"
   204:
@@ -439,7 +438,7 @@ selectors:
     name: "fantom-mainnet"
   480:
     selector: 2049429975587534727
-    name: "ethereum-mainnet-worldchain-1" 
+    name: "ethereum-mainnet-worldchain-1"
   21000000:
     selector: 9043146809313071210
     name: "corn-mainnet"

--- a/selectors.yml
+++ b/selectors.yml
@@ -29,7 +29,7 @@ selectors:
     name: "velas-testnet"
   195:
     selector: 2066098519157881736
-    name: "ethereum-testnet-sepolia-xlayer-1"
+    name: "ethereum-testnet-sepolia-xlayer-1"  
   280:
     selector: 6802309497652714138
     name: "ethereum-testnet-goerli-zksync-1"
@@ -230,6 +230,9 @@ selectors:
   1328:
     selector: 1216300075444106652
     name: "sei-testnet-atlantic"
+  57054:
+    selector: 3676871237479449268
+    name: "sonic-testnet-blaze"
   998:
     selector: 4286062357653186312
     name: "hyperliquid-testnet"
@@ -254,6 +257,7 @@ selectors:
   4801:
     selector: 5299555114858065850
     name: "ethereum-testnet-sepolia-worldchain-1"
+ 
 
   # Mainnets
   1:
@@ -421,7 +425,7 @@ selectors:
   1329:
     selector: 9027416829622342829
     name: "sei-mainnet"
-  2020:
+  2020: 
     selector: 6916147374840168594
     name: "ronin-mainnet"
   204:
@@ -435,7 +439,7 @@ selectors:
     name: "fantom-mainnet"
   480:
     selector: 2049429975587534727
-    name: "ethereum-mainnet-worldchain-1"
+    name: "ethereum-mainnet-worldchain-1" 
   21000000:
     selector: 9043146809313071210
     name: "corn-mainnet"


### PR DESCRIPTION
This PR adds in immutability checks for `chain-selectors`. 

It's a simple GHA that checks out the previous ref and the current ref and ensures selectors are not modified. Decided to just use yq here, nothing fancy.