### PR TITLE
Support for Tron as an EVM Chain

### DIFF
--- a/generated_chains_evm.go
+++ b/generated_chains_evm.go
@@ -282,7 +282,9 @@ var (
 	TEST_98865                                     = Chain{EvmChainID: 98865, Selector: 3208172210661564830, Name: "98865"}
 	TREASURE_MAINNET                               = Chain{EvmChainID: 61166, Selector: 5214452172935136222, Name: "treasure-mainnet"}
 	TREASURE_TESTNET_TOPAZ                         = Chain{EvmChainID: 978658, Selector: 3676916124122457866, Name: "treasure-testnet-topaz"}
-	TRON_TESTNET_NILE                              = Chain{EvmChainID: 3448148188, Selector: 2052925811360307749, Name: "tron-testnet-nile"}
+	TRON_MAINNET_EVM                               = Chain{EvmChainID: 728126428, Selector: 1546563616611573946, Name: "tron-mainnet-evm"}
+	TRON_TESTNET_NILE_EVM                          = Chain{EvmChainID: 3448148188, Selector: 2052925811360307749, Name: "tron-testnet-nile-evm"}
+	TRON_TESTNET_SHASTA_EVM                        = Chain{EvmChainID: 2494104990, Selector: 13231703482326770598, Name: "tron-testnet-shasta-evm"}
 	VELAS_MAINNET                                  = Chain{EvmChainID: 106, Selector: 374210358663784372, Name: "velas-mainnet"}
 	VELAS_TESTNET                                  = Chain{EvmChainID: 111, Selector: 572210378683744374, Name: "velas-testnet"}
 	WEMIX_MAINNET                                  = Chain{EvmChainID: 1111, Selector: 5142893604156789321, Name: "wemix-mainnet"}
@@ -565,7 +567,9 @@ var ALL = []Chain{
 	TEST_98865,
 	TREASURE_MAINNET,
 	TREASURE_TESTNET_TOPAZ,
-	TRON_TESTNET_NILE,
+	TRON_MAINNET_EVM,
+	TRON_TESTNET_NILE_EVM,
+	TRON_TESTNET_SHASTA_EVM,
 	VELAS_MAINNET,
 	VELAS_TESTNET,
 	WEMIX_MAINNET,

--- a/generated_chains_evm.go
+++ b/generated_chains_evm.go
@@ -282,6 +282,7 @@ var (
 	TEST_98865                                     = Chain{EvmChainID: 98865, Selector: 3208172210661564830, Name: "98865"}
 	TREASURE_MAINNET                               = Chain{EvmChainID: 61166, Selector: 5214452172935136222, Name: "treasure-mainnet"}
 	TREASURE_TESTNET_TOPAZ                         = Chain{EvmChainID: 978658, Selector: 3676916124122457866, Name: "treasure-testnet-topaz"}
+	TRON_TESTNET_NILE                              = Chain{EvmChainID: 3448148188, Selector: 2052925811360307749, Name: "tron-testnet-nile"}
 	VELAS_MAINNET                                  = Chain{EvmChainID: 106, Selector: 374210358663784372, Name: "velas-mainnet"}
 	VELAS_TESTNET                                  = Chain{EvmChainID: 111, Selector: 572210378683744374, Name: "velas-testnet"}
 	WEMIX_MAINNET                                  = Chain{EvmChainID: 1111, Selector: 5142893604156789321, Name: "wemix-mainnet"}
@@ -564,6 +565,7 @@ var ALL = []Chain{
 	TEST_98865,
 	TREASURE_MAINNET,
 	TREASURE_TESTNET_TOPAZ,
+	TRON_TESTNET_NILE,
 	VELAS_MAINNET,
 	VELAS_TESTNET,
 	WEMIX_MAINNET,

--- a/generated_chains_tron.go
+++ b/generated_chains_tron.go
@@ -10,12 +10,10 @@ type TronChain struct {
 
 var (
 	TRON_MAINNET        = TronChain{ChainID: 728126428, Selector: 1546563616611573946, Name: "tron-mainnet"}
-	TRON_TESTNET_NILE   = TronChain{ChainID: 3448148188, Selector: 2052925811360307749, Name: "tron-testnet-nile"}
 	TRON_TESTNET_SHASTA = TronChain{ChainID: 2494104990, Selector: 13231703482326770598, Name: "tron-testnet-shasta"}
 )
 
 var TronALL = []TronChain{
 	TRON_MAINNET,
-	TRON_TESTNET_NILE,
 	TRON_TESTNET_SHASTA,
 }

--- a/generated_chains_tron.go
+++ b/generated_chains_tron.go
@@ -9,9 +9,9 @@ type TronChain struct {
 }
 
 var (
-	TRON_MAINNET        = TronChain{ChainID: 728126428, Selector: 1546563616611573946, Name: "tron-mainnet"}
-	TRON_TESTNET_NILE   = TronChain{ChainID: 3448148188, Selector: 2052925811360307749, Name: "tron-testnet-nile"}
-	TRON_TESTNET_SHASTA = TronChain{ChainID: 2494104990, Selector: 13231703482326770598, Name: "tron-testnet-shasta"}
+	TRON_MAINNET        = TronChain{ChainID: 728126428, Selector: 1546563616611573945, Name: "tron-mainnet"}
+	TRON_TESTNET_NILE   = TronChain{ChainID: 3448148188, Selector: 2052925811360307740, Name: "tron-testnet-nile"}
+	TRON_TESTNET_SHASTA = TronChain{ChainID: 2494104990, Selector: 13231703482326770597, Name: "tron-testnet-shasta"}
 )
 
 var TronALL = []TronChain{

--- a/generated_chains_tron.go
+++ b/generated_chains_tron.go
@@ -10,10 +10,12 @@ type TronChain struct {
 
 var (
 	TRON_MAINNET        = TronChain{ChainID: 728126428, Selector: 1546563616611573946, Name: "tron-mainnet"}
+	TRON_TESTNET_NILE   = TronChain{ChainID: 3448148188, Selector: 2052925811360307749, Name: "tron-testnet-nile"}
 	TRON_TESTNET_SHASTA = TronChain{ChainID: 2494104990, Selector: 13231703482326770598, Name: "tron-testnet-shasta"}
 )
 
 var TronALL = []TronChain{
 	TRON_MAINNET,
+	TRON_TESTNET_NILE,
 	TRON_TESTNET_SHASTA,
 }

--- a/selectors.yml
+++ b/selectors.yml
@@ -532,4 +532,10 @@ selectors:
     name: "mind-mainnet"
   3448148188:
     selector: 2052925811360307749
-    name: "tron-testnet-nile"
+    name: "tron-testnet-nile-evm"
+  2494104990:
+    selector: 13231703482326770598
+    name: "tron-testnet-shasta-evm"
+  728126428:
+    selector: 1546563616611573946
+    name: "tron-mainnet-evm"

--- a/selectors.yml
+++ b/selectors.yml
@@ -530,3 +530,6 @@ selectors:
   228:
     selector: 11690709103138290329
     name: "mind-mainnet"
+  3448148188:
+    selector: 2052925811360307749
+    name: "tron-testnet-nile"

--- a/selectors_tron.yml
+++ b/selectors_tron.yml
@@ -1,4 +1,7 @@
 selectors:
+  3448148188:
+    selector: 2052925811360307749
+    name: "tron-testnet-nile"
   2494104990:
     selector: 13231703482326770598
     name: "tron-testnet-shasta"

--- a/selectors_tron.yml
+++ b/selectors_tron.yml
@@ -1,7 +1,4 @@
 selectors:
-  3448148188:
-    selector: 2052925811360307749
-    name: "tron-testnet-nile"
   2494104990:
     selector: 13231703482326770598
     name: "tron-testnet-shasta"

--- a/selectors_tron.yml
+++ b/selectors_tron.yml
@@ -1,10 +1,10 @@
 selectors:
   3448148188:
-    selector: 2052925811360307749
+    selector: 2052925811360307740
     name: "tron-testnet-nile"
   2494104990:
-    selector: 13231703482326770598
+    selector: 13231703482326770597
     name: "tron-testnet-shasta"
   728126428:
-    selector: 1546563616611573946
+    selector: 1546563616611573945
     name: "tron-mainnet"

--- a/tron_test.go
+++ b/tron_test.go
@@ -17,19 +17,19 @@ func Test_TronYmlAreValid(t *testing.T) {
 	}{
 		{
 			name:          "tron-mainnet",
-			chainSelector: 1546563616611573946,
+			chainSelector: 1546563616611573945,
 			chainsId:      728126428,
 			expectErr:     false,
 		},
 		{
 			name:          "tron-testnet-nile",
-			chainSelector: 2052925811360307749,
+			chainSelector: 2052925811360307740,
 			chainsId:      3448148188,
 			expectErr:     false,
 		},
 		{
 			name:          "tron-testnet-shasta",
-			chainSelector: 13231703482326770598,
+			chainSelector: 13231703482326770597,
 			chainsId:      2494104990,
 			expectErr:     false,
 		},


### PR DESCRIPTION
> Note: This PR modifies the exisiting Tron chain-selectors, have verified they aren't currently used anywhere.

This PR adds Tron as an EVM chain to allow for use within the EVM relayer. To do this we've reused the tron selectors in the EVM family and updated the original selectors in the tron family to not conflict.

Main reason for not keeping the existing Tron selectors is we have an existing deployment on staging. Though it's worth noting we've checked to ensure this won't have a downstream impact