### PR TITLE
Add missing Nexon networks

### DIFF
--- a/generated_chains_evm.go
+++ b/generated_chains_evm.go
@@ -154,6 +154,11 @@ var (
 	NEAR_TESTNET                                   = Chain{EvmChainID: 398, Selector: 5061593697262339000, Name: "near-testnet"}
 	NEONLINK_MAINNET                               = Chain{EvmChainID: 259, Selector: 8239338020728974000, Name: "neonlink-mainnet"}
 	NEONLINK_TESTNET                               = Chain{EvmChainID: 9559, Selector: 1113014352258747600, Name: "neonlink-testnet"}
+	NEXON_DEV                                      = Chain{EvmChainID: 5668, Selector: 8911150974185440581, Name: "nexon-dev"}
+	NEXON_MAINNET_HENESYS                          = Chain{EvmChainID: 68414, Selector: 12657445206920369324, Name: "nexon-mainnet-henesys"}
+	NEXON_MAINNET_LITH                             = Chain{EvmChainID: 60118, Selector: 15758750456714168963, Name: "nexon-mainnet-lith"}
+	NEXON_QA                                       = Chain{EvmChainID: 807424, Selector: 14632960069656270105, Name: "nexon-qa"}
+	NEXON_STAGE                                    = Chain{EvmChainID: 847799, Selector: 5556806327594153475, Name: "nexon-stage"}
 	NIBIRU_MAINNET                                 = Chain{EvmChainID: 6900, Selector: 17349189558768828726, Name: "nibiru-mainnet"}
 	NIBIRU_TESTNET                                 = Chain{EvmChainID: 6930, Selector: 305104239123120457, Name: "nibiru-testnet"}
 	PLUME_DEVNET                                   = Chain{EvmChainID: 98864, Selector: 3743020999916460931, Name: "plume-devnet"}
@@ -451,6 +456,11 @@ var ALL = []Chain{
 	NEAR_TESTNET,
 	NEONLINK_MAINNET,
 	NEONLINK_TESTNET,
+	NEXON_DEV,
+	NEXON_MAINNET_HENESYS,
+	NEXON_MAINNET_LITH,
+	NEXON_QA,
+	NEXON_STAGE,
 	NIBIRU_MAINNET,
 	NIBIRU_TESTNET,
 	PLUME_DEVNET,

--- a/selectors.yml
+++ b/selectors.yml
@@ -218,9 +218,18 @@ selectors:
   686868:
     selector: 5269261765892944301
     name: "bitcoin-testnet-merlin"
+  5668:
+    selector: 8911150974185440581
+    name: "nexon-dev"
   595581:
     selector: 7837562506228496256
     name: "avalanche-testnet-nexon"
+  807424:
+    selector: 14632960069656270105
+    name: "nexon-qa"
+  847799:
+    selector: 5556806327594153475
+    name: "nexon-stage"
   810181:
     selector: 5837261596322416298
     name: "zklink_nova-testnet"
@@ -322,6 +331,8 @@ selectors:
   6930:
     selector: 305104239123120457
     name: "nibiru-testnet"
+  
+
 
   # Mainnets
   1:
@@ -575,3 +586,9 @@ selectors:
   6900:
     selector: 17349189558768828726
     name: "nibiru-mainnet"
+  60118:
+    selector: 15758750456714168963
+    name: "nexon-mainnet-lith"
+  68414:
+    selector: 12657445206920369324
+    name: "nexon-mainnet-henesys"


### PR DESCRIPTION
Nexon currently has six different networks, which all now have chain-selectors entries after this PR:

- Nexon Dev
- Nexon Test
- Nexon QA
- Nexon Stage
- Nexon Mainnet (Lith, old/current)
- Nexon Mainnet (Henesys, current/future)

https://smartcontract-it.atlassian.net/browse/BCY-1777
https://chainlink-core.slack.com/archives/C07JJ5LKF6W/p1744178269390189