### PR TITLE
Add chainselectors for Kaia testnet and mainnet

### DIFF
--- a/generated_chains_evm.go
+++ b/generated_chains_evm.go
@@ -139,6 +139,8 @@ var (
 	INK_TESTNET_SEPOLIA                            = Chain{EvmChainID: 763373, Selector: 9763904284804119144, Name: "ink-testnet-sepolia"}
 	JANCTION_MAINNET                               = Chain{EvmChainID: 678, Selector: 9107126442626377432, Name: "janction-mainnet"}
 	JANCTION_TESTNET_SEPOLIA                       = Chain{EvmChainID: 679, Selector: 5059197667603797935, Name: "janction-testnet-sepolia"}
+	KAIA_MAINNET                                   = Chain{EvmChainID: 8217, Selector: 9813823125703490621, Name: "kaia-mainnet"}
+	KAIA_TESTNET_KAIROS                            = Chain{EvmChainID: 1001, Selector: 2624132734533621656, Name: "kaia-testnet-kairos"}
 	KAVA_MAINNET                                   = Chain{EvmChainID: 2222, Selector: 7550000543357438061, Name: "kava-mainnet"}
 	KAVA_TESTNET                                   = Chain{EvmChainID: 2221, Selector: 2110537777356199208, Name: "kava-testnet"}
 	KUSAMA_MAINNET_MOONRIVER                       = Chain{EvmChainID: 1285, Selector: 1355020143337428062, Name: "kusama-mainnet-moonriver"}
@@ -463,6 +465,8 @@ var ALL = []Chain{
 	INK_TESTNET_SEPOLIA,
 	JANCTION_MAINNET,
 	JANCTION_TESTNET_SEPOLIA,
+	KAIA_MAINNET,
+	KAIA_TESTNET_KAIROS,
 	KAVA_MAINNET,
 	KAVA_TESTNET,
 	KUSAMA_MAINNET_MOONRIVER,

--- a/selectors.yml
+++ b/selectors.yml
@@ -72,6 +72,9 @@ selectors:
   919:
     selector: 829525985033418733
     name: "ethereum-testnet-sepolia-mode-1"
+  1001:
+    selector: 2624132734533621656
+    name: "kaia-testnet-kairos"
   1029:
     selector: 4459371029167934217
     name: "bittorrent_chain-testnet"
@@ -504,6 +507,9 @@ selectors:
   5000:
     selector: 1556008542357238666
     name: "ethereum-mainnet-mantle-1"
+  8217:
+    selector: 9813823125703490621
+    name: "kaia-mainnet"
   8453:
     selector: 15971525489660198786
     name: "ethereum-mainnet-base-1"


### PR DESCRIPTION
Preparing the chain selectors for the Kaia testnet and mainnet now that we're about to start the integration process.

https://smartcontract-it.atlassian.net/browse/BCY-2147
https://smartcontract-it.atlassian.net/browse/BCY-2148