### PR TITLE
feat: implement Aptos chain ID validation

### DIFF
--- a/aptos.go
+++ b/aptos.go
@@ -60,7 +60,27 @@ func parseAptosYml(ymlFile []byte) map[uint64]ChainDetails {
 }
 
 func validateAptosChainID(data map[uint64]ChainDetails) error {
-	// TODO: https://smartcontract-it.atlassian.net/browse/NONEVM-890
+	seenSelectors := make(map[uint64]uint64) // selector -> chainID
+	for chainID, details := range data {
+		if chainID == 0 {
+			return fmt.Errorf("invalid aptos chain ID: must be > 0")
+		}
+		if details.ChainSelector == 0 {
+			return fmt.Errorf("invalid chain selector for aptos chain %d: must be > 0", chainID)
+		}
+		if details.ChainName == "" {
+			return fmt.Errorf("chain name is empty for aptos chain %d", chainID)
+		}
+		if details.NetworkType != NetworkTypeTestnet && details.NetworkType != NetworkTypeMainnet {
+			return fmt.Errorf("invalid network type %q for aptos chain %d: must be %q or %q",
+				details.NetworkType, chainID, NetworkTypeTestnet, NetworkTypeMainnet)
+		}
+		if existingChainID, exists := seenSelectors[details.ChainSelector]; exists {
+			return fmt.Errorf("duplicate chain selector %d: used by both aptos chain %d and %d",
+				details.ChainSelector, existingChainID, chainID)
+		}
+		seenSelectors[details.ChainSelector] = chainID
+	}
 	return nil
 }
 

--- a/aptos_test.go
+++ b/aptos_test.go
@@ -82,3 +82,53 @@ func Test_AptosGetChainIDByChainSelector(t *testing.T) {
 		assert.Equal(t, chainID, fmt.Sprintf("%v", k))
 	}
 }
+
+func Test_ValidateAptosChainID(t *testing.T) {
+	t.Run("valid data passes", func(t *testing.T) {
+		data := map[uint64]ChainDetails{
+			1: {ChainSelector: 100, ChainName: "aptos-mainnet", NetworkType: NetworkTypeMainnet},
+			2: {ChainSelector: 200, ChainName: "aptos-testnet", NetworkType: NetworkTypeTestnet},
+		}
+		assert.NoError(t, validateAptosChainID(data))
+	})
+
+	t.Run("zero chain ID fails", func(t *testing.T) {
+		data := map[uint64]ChainDetails{
+			0: {ChainSelector: 100, ChainName: "aptos-invalid", NetworkType: NetworkTypeMainnet},
+		}
+		assert.ErrorContains(t, validateAptosChainID(data), "invalid aptos chain ID")
+	})
+
+	t.Run("zero selector fails", func(t *testing.T) {
+		data := map[uint64]ChainDetails{
+			1: {ChainSelector: 0, ChainName: "aptos-mainnet", NetworkType: NetworkTypeMainnet},
+		}
+		assert.ErrorContains(t, validateAptosChainID(data), "invalid chain selector")
+	})
+
+	t.Run("empty chain name fails", func(t *testing.T) {
+		data := map[uint64]ChainDetails{
+			1: {ChainSelector: 100, ChainName: "", NetworkType: NetworkTypeMainnet},
+		}
+		assert.ErrorContains(t, validateAptosChainID(data), "chain name is empty")
+	})
+
+	t.Run("invalid network type fails", func(t *testing.T) {
+		data := map[uint64]ChainDetails{
+			1: {ChainSelector: 100, ChainName: "aptos-mainnet", NetworkType: "invalid"},
+		}
+		assert.ErrorContains(t, validateAptosChainID(data), "invalid network type")
+	})
+
+	t.Run("duplicate selector fails", func(t *testing.T) {
+		data := map[uint64]ChainDetails{
+			1: {ChainSelector: 100, ChainName: "aptos-mainnet", NetworkType: NetworkTypeMainnet},
+			2: {ChainSelector: 100, ChainName: "aptos-testnet", NetworkType: NetworkTypeTestnet},
+		}
+		assert.ErrorContains(t, validateAptosChainID(data), "duplicate chain selector")
+	})
+
+	t.Run("existing aptos selectors are valid", func(t *testing.T) {
+		assert.NoError(t, validateAptosChainID(aptosSelectorsMap))
+	})
+}

--- a/extra_selectors_test.go
+++ b/extra_selectors_test.go
@@ -65,6 +65,7 @@ aptos:
   888:
     selector: 9876543210987654321
     name: "test-aptos-chain"
+    network_type: testnet
 sui:
   777:
     selector: 2222222222222222222


### PR DESCRIPTION
## Summary

Basic validation and hardening of Aptos chain selectors. Replaces the TODO stub in validateAptosChainID with proper validation: chain ID > 0, selector > 0, non-empty chain name, valid network type, and duplicate selector detection. Adds comprehensive unit tests and fixes missing network_type in extra selectors test fixture.

## Test plan

- [x] All existing tests pass
- [x] New Test_ValidateAptosChainID covers valid data, zero chain ID, zero selector, empty name, invalid network type, duplicate selectors, and existing selectors