### PR TITLE
feat: track deprecated chains through deprecated flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,13 @@ details, err := chainsel.GetChainDetailsBySelector(ctx, 5009297550715157269)
 
 // Get chain details by chain ID and family
 details, err := chainsel.GetChainDetailsByChainIDAndFamily(ctx, "1", "evm")
-// Returns: ChainDetails{ChainSelector: 5009297550715157269, ChainName: "ethereum-mainnet"}
+// Returns: ChainDetails{ChainSelector: 5009297550715157269, ChainName: "ethereum-mainnet", Deprecated: false}
+
+// Check whether a selector has been deprecated
+deprecated, err := chainselectors.IsDeprecated(5009297550715157269)
+
+// Or with the remote API
+deprecated, err = chainsel.IsDeprecated(ctx, 5009297550715157269)
 ```
 
 #### EVM-Specific Functions

--- a/all_selectors.yml
+++ b/all_selectors.yml
@@ -299,7 +299,6 @@ evm:
         selector: 4348158687435793198
         name: ethereum-mainnet-polygon-zkevm-1
         network_type: mainnet
-        deprecated: true
     1111:
         selector: 5142893604156789321
         name: wemix-mainnet
@@ -462,7 +461,6 @@ evm:
         selector: 1654667687261492630
         name: ethereum-testnet-sepolia-polygon-zkevm-1
         network_type: testnet
-        deprecated: true
     2522:
         selector: 8901520481741771655
         name: ethereum-testnet-holesky-fraxtal-1
@@ -647,7 +645,6 @@ evm:
         selector: 1763698235108410440
         name: sonic-testnet
         network_type: testnet
-        deprecated: true
     16600:
         selector: 16088006396410204581
         name: 0g-testnet-newton

--- a/all_selectors.yml
+++ b/all_selectors.yml
@@ -846,6 +846,7 @@ evm:
         selector: 12336603543561911511
         name: berachain-testnet-artio
         network_type: testnet
+        deprecated: true
     80087:
         selector: 2285225387454015855
         name: zero-g-testnet-galileo
@@ -1035,6 +1036,7 @@ evm:
         selector: 10443705513486043421
         name: ethereum-testnet-sepolia-arbitrum-1-treasure-1
         network_type: testnet
+        deprecated: true
     978658:
         selector: 3676916124122457866
         name: treasure-testnet-topaz
@@ -1044,6 +1046,7 @@ evm:
         selector: 1010349088906777999
         name: ethereum-mainnet-arbitrum-1-treasure-1
         network_type: mainnet
+        deprecated: true
     2019775:
         selector: 945045181441419236
         name: jovay-testnet

--- a/all_selectors.yml
+++ b/all_selectors.yml
@@ -123,10 +123,12 @@ evm:
         selector: 17164792800244661392
         name: mint-mainnet
         network_type: mainnet
+        deprecated: true
     195:
         selector: 2066098519157881736
         name: ethereum-testnet-sepolia-xlayer-1
         network_type: testnet
+        deprecated: true
     196:
         selector: 3016212468291539606
         name: ethereum-mainnet-xlayer-1
@@ -171,6 +173,7 @@ evm:
         selector: 3719320017875267166
         name: ethereum-mainnet-kroma-1
         network_type: mainnet
+        deprecated: true
     259:
         selector: 8239338020728974000
         name: neonlink-mainnet
@@ -247,6 +250,7 @@ evm:
         selector: 5059197667603797935
         name: janction-testnet-sepolia
         network_type: testnet
+        deprecated: true
     682:
         selector: 6260932437388305511
         name: private-testnet-obsidian
@@ -295,6 +299,7 @@ evm:
         selector: 4348158687435793198
         name: ethereum-mainnet-polygon-zkevm-1
         network_type: mainnet
+        deprecated: true
     1111:
         selector: 5142893604156789321
         name: wemix-mainnet
@@ -315,6 +320,7 @@ evm:
         selector: 1948510578179542068
         name: bitcoin-testnet-bsquared-1
         network_type: testnet
+        deprecated: true
     1135:
         selector: 15293031020466096408
         name: lisk-mainnet
@@ -355,6 +361,7 @@ evm:
         selector: 11059667695644972511
         name: ethereum-testnet-goerli-polygon-zkevm-1
         network_type: testnet
+        deprecated: true
     1513:
         selector: 4237030917318060427
         name: story-testnet
@@ -367,6 +374,7 @@ evm:
         selector: 10749384167430721561
         name: mint-testnet
         network_type: testnet
+        deprecated: true
     1740:
         selector: 6286293440461807648
         name: metal-testnet
@@ -403,6 +411,7 @@ evm:
         selector: 13116810400804392105
         name: ronin-testnet-saigon
         network_type: testnet
+        deprecated: true
     2023:
         selector: 3260900564719373474
         name: private-testnet-granite
@@ -427,6 +436,7 @@ evm:
         selector: 12168171414969487009
         name: memento-testnet
         network_type: testnet
+        deprecated: true
     2201:
         selector: 11793402411494852765
         name: stable-testnet
@@ -443,6 +453,7 @@ evm:
         selector: 5990477251245693094
         name: ethereum-testnet-sepolia-kroma-1
         network_type: testnet
+        deprecated: true
     2391:
         selector: 9488606126177218005
         name: tac-testnet
@@ -451,10 +462,12 @@ evm:
         selector: 1654667687261492630
         name: ethereum-testnet-sepolia-polygon-zkevm-1
         network_type: testnet
+        deprecated: true
     2522:
         selector: 8901520481741771655
         name: ethereum-testnet-holesky-fraxtal-1
         network_type: testnet
+        deprecated: true
     2741:
         selector: 3577778157919314504
         name: abstract-mainnet
@@ -463,6 +476,7 @@ evm:
         selector: 8304510386741731151
         name: ethereum-testnet-holesky-morph-1
         network_type: testnet
+        deprecated: true
     2818:
         selector: 18164309074156128038
         name: morph-mainnet
@@ -479,6 +493,7 @@ evm:
         selector: 1467223411771711614
         name: bitcoin-testnet-botanix
         network_type: testnet
+        deprecated: true
     3637:
         selector: 4560701533377838164
         name: bitcoin-mainnet-botanix
@@ -543,6 +558,7 @@ evm:
         selector: 2443239559770384419
         name: megaeth-testnet
         network_type: testnet
+        deprecated: true
     6343:
         selector: 18241817625092392675
         name: megaeth-testnet-2
@@ -627,14 +643,17 @@ evm:
         selector: 1763698235108410440
         name: sonic-testnet
         network_type: testnet
+        deprecated: true
     16600:
         selector: 16088006396410204581
         name: 0g-testnet-newton
         network_type: testnet
+        deprecated: true
     16601:
         selector: 2131427466778448014
         name: 0g-testnet-galileo
         network_type: testnet
+        deprecated: true
     16602:
         selector: 6892437333620424805
         name: 0g-testnet-galileo-1
@@ -647,10 +666,12 @@ evm:
         selector: 7717148896336251131
         name: ethereum-testnet-holesky
         network_type: testnet
+        deprecated: true
     25327:
         selector: 9723842205701363942
         name: everclear-mainnet
         network_type: mainnet
+        deprecated: true
     26888:
         selector: 7051849327615092843
         name: ab-testnet
@@ -699,6 +720,7 @@ evm:
         selector: 3963528237232804922
         name: tempo-testnet
         network_type: testnet
+        deprecated: true
     42431:
         selector: 8457817439310187923
         name: tempo-testnet-moderato
@@ -723,6 +745,7 @@ evm:
         selector: 3552045678561919002
         name: celo-testnet-alfajores
         network_type: testnet
+        deprecated: true
     45439:
         selector: 8446413392851542429
         name: private-testnet-opala
@@ -751,6 +774,7 @@ evm:
         selector: 6473245816409426016
         name: memento-mainnet
         network_type: mainnet
+        deprecated: true
     53302:
         selector: 13694007683517087973
         name: superseed-testnet
@@ -759,6 +783,7 @@ evm:
         selector: 3676871237479449268
         name: sonic-testnet-blaze
         network_type: testnet
+        deprecated: true
     57073:
         selector: 3461204551265785888
         name: ethereum-mainnet-ink-1
@@ -791,6 +816,7 @@ evm:
         selector: 5214452172935136222
         name: treasure-mainnet
         network_type: mainnet
+        deprecated: true
     68414:
         selector: 12657445206920369324
         name: nexon-mainnet-henesys
@@ -815,6 +841,7 @@ evm:
         selector: 8999465244383784164
         name: berachain-testnet-bartio
         network_type: testnet
+        deprecated: true
     80085:
         selector: 12336603543561911511
         name: berachain-testnet-artio
@@ -823,6 +850,7 @@ evm:
         selector: 2285225387454015855
         name: zero-g-testnet-galileo
         network_type: testnet
+        deprecated: true
     80094:
         selector: 1294465214383781161
         name: berachain-mainnet
@@ -875,10 +903,12 @@ evm:
         selector: 1910019406958449359
         name: etherlink-testnet
         network_type: testnet
+        deprecated: true
     129399:
         selector: 9090863410735740267
         name: polygon-testnet-tatara
         network_type: testnet
+        deprecated: true
     167000:
         selector: 16468599424800719238
         name: ethereum-mainnet-taiko-1
@@ -887,6 +917,7 @@ evm:
         selector: 7248756420937879088
         name: ethereum-testnet-holesky-taiko-1
         network_type: testnet
+        deprecated: true
     167012:
         selector: 9873759436596923887
         name: ethereum-testnet-hoodi-taiko
@@ -955,6 +986,7 @@ evm:
         selector: 4012524741200567430
         name: pharos-testnet
         network_type: testnet
+        deprecated: true
     688689:
         selector: 16098325658947243212
         name: pharos-atlantic-testnet
@@ -1007,6 +1039,7 @@ evm:
         selector: 3676916124122457866
         name: treasure-testnet-topaz
         network_type: testnet
+        deprecated: true
     978670:
         selector: 1010349088906777999
         name: ethereum-mainnet-arbitrum-1-treasure-1
@@ -1067,6 +1100,7 @@ evm:
         selector: 2027362563942762617
         name: ethereum-testnet-sepolia-blast-1
         network_type: testnet
+        deprecated: true
     728126428:
         selector: 1546563616611573946
         name: tron-mainnet-evm

--- a/extra_selectors_test.go
+++ b/extra_selectors_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func createTempYamlFile(t *testing.T, yamlContent string) string {
@@ -53,6 +54,7 @@ evm:
   999:
     selector: 1234567890123456789
     name: "test-evm-chain"
+    deprecated: true
 solana:
   "ASwXBTzJM5evpfrWSHSjZaxPErZRuiGJnFixGUHi4NQT":  #Random solana chainID
     selector: 1111111111111111111
@@ -95,6 +97,7 @@ func TestExtraSelectors(t *testing.T) {
 		assert.True(t, exists)
 		assert.Equal(t, uint64(1234567890123456789), evmChain.ChainSelector)
 		assert.Equal(t, "test-evm-chain", evmChain.ChainName)
+		assert.False(t, evmChain.Deprecated)
 	})
 
 	runTestWithYaml(t, "Extra selectors: multiple families", yamlMultipleFamilies, func(t *testing.T, result ExtraSelectorsData) {
@@ -114,6 +117,10 @@ func TestExtraSelectors(t *testing.T) {
 		assert.True(t, exists)
 		assert.Equal(t, uint64(2222222222222222222), suiChain.ChainSelector)
 		assert.Equal(t, "test-sui-chain", suiChain.ChainName)
+
+		evmChain, exists := result.Evm[999]
+		assert.True(t, exists)
+		assert.True(t, evmChain.Deprecated)
 	})
 
 	runTestWithYaml(t, "Extra selectors: empty YAML file", ``, func(t *testing.T, result ExtraSelectorsData) {
@@ -126,6 +133,22 @@ func TestExtraSelectors(t *testing.T) {
 		assert.Empty(t, result.Starknet)
 	})
 
+}
+
+func TestExtraSelectorsMarshalDeprecatedField(t *testing.T) {
+	data := ExtraSelectorsData{
+		Evm: map[uint64]ChainDetails{
+			999: {
+				ChainSelector: 1234567890123456789,
+				ChainName:     "test-evm-chain",
+				Deprecated:    true,
+			},
+		},
+	}
+
+	output, err := yaml.Marshal(data)
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "deprecated: true")
 }
 
 func TestExtraSelectorsInvalidFormat(t *testing.T) {
@@ -214,6 +237,15 @@ func TestExtraSelectorsE2E(t *testing.T) {
 	name, err = NameFromChainId(999)
 	assert.NoError(t, err)
 	assert.Equal(t, "hyperliquid-mainnet", name)
+
+	// Deprecated flag on extra selectors propagates through to IsDeprecated.
+	deprecated, err := IsDeprecated(1357913579135791357)
+	assert.NoError(t, err)
+	assert.True(t, deprecated)
+
+	deprecated, err = IsDeprecated(1234567890123456789)
+	assert.NoError(t, err)
+	assert.False(t, deprecated)
 }
 
 // Validates a custom provide file for formating errors. This can be used in external CI checks to ensure the file is valid.

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -470,6 +470,16 @@ func GetChainDetailsByChainIDAndFamily(ctx context.Context, chainID string, fami
 	}
 }
 
+// IsDeprecated reports whether the chain for the given selector has been sunset or superseded
+func IsDeprecated(ctx context.Context, selector uint64, opts ...Option) (bool, error) {
+	details, err := GetChainDetailsBySelector(ctx, selector, opts...)
+	if err != nil {
+		return false, err
+	}
+
+	return details.Deprecated, nil
+}
+
 // ClearCache clears the remote data cache, forcing the next remote call to fetch fresh data
 func ClearCache() {
 	remoteCacheLock.Lock()

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -22,6 +22,10 @@ evm:
   10:
     selector: 3734403246176062136
     name: optimism-mainnet
+  777777:
+    selector: 1777777777777777777
+    name: remote-only-mainnet
+    deprecated: true
   56:
     selector: 11344663589394136015
     name: bsc-mainnet
@@ -145,6 +149,34 @@ func TestGetChainDetailsByChainIDAndFamily(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(124615329519749607), details.ChainSelector)
 	assert.Equal(t, "solana-mainnet", details.ChainName)
+}
+
+func TestIsDeprecated(t *testing.T) {
+	ClearCache()
+	server := newMockServer()
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+
+	deprecated, err := IsDeprecated(ctx, uint64(5009297550715157269),
+		WithURL(server.URL),
+		WithTimeout(5*time.Second),
+	)
+	require.NoError(t, err)
+	assert.False(t, deprecated)
+
+	deprecated, err = IsDeprecated(ctx, uint64(1777777777777777777),
+		WithURL(server.URL),
+		WithTimeout(5*time.Second),
+	)
+	require.NoError(t, err)
+	assert.True(t, deprecated)
+
+	_, err = IsDeprecated(ctx, uint64(999999999999999999),
+		WithURL(server.URL),
+		WithTimeout(5*time.Second),
+	)
+	assert.Error(t, err)
 }
 
 func TestRemoteWithMockServer(t *testing.T) {

--- a/selectors.go
+++ b/selectors.go
@@ -364,6 +364,16 @@ func IsTestnetChain(selector uint64) (bool, error) {
 	return networkType == NetworkTypeTestnet, nil
 }
 
+// IsDeprecated reports whether the chain for the given selector has been sunset or superseded.
+func IsDeprecated(selector uint64) (bool, error) {
+	chainDetails, err := GetChainDetails(selector)
+	if err != nil {
+		return false, err
+	}
+
+	return chainDetails.Deprecated, nil
+}
+
 func GetChainDetails(selector uint64) (ChainDetails, error) {
 	chainInfo, err := getChainInfo(selector)
 	if err != nil {

--- a/selectors.yml
+++ b/selectors.yml
@@ -287,6 +287,7 @@ selectors:
     selector: 12336603543561911511
     name: "berachain-testnet-artio"
     network_type: testnet
+    deprecated: true
   80084:
     selector: 8999465244383784164
     name: "berachain-testnet-bartio"
@@ -399,6 +400,7 @@ selectors:
     selector: 10443705513486043421
     name: "ethereum-testnet-sepolia-arbitrum-1-treasure-1"
     network_type: testnet
+    deprecated: true
   1946:
     selector: 686603546605904534
     name: "ethereum-testnet-sepolia-soneium-1"
@@ -942,6 +944,7 @@ selectors:
     selector: 1010349088906777999
     name: "ethereum-mainnet-arbitrum-1-treasure-1"
     network_type: mainnet
+    deprecated: true
   48900:
     selector: 17198166215261833993
     name: "ethereum-mainnet-zircuit-1"

--- a/selectors.yml
+++ b/selectors.yml
@@ -47,6 +47,7 @@ selectors:
     selector: 2066098519157881736
     name: "ethereum-testnet-sepolia-xlayer-1"
     network_type: testnet
+    deprecated: true
   240:
     selector: 16487132492576884721
     name: "cronos-zkevm-testnet-sepolia"
@@ -91,6 +92,7 @@ selectors:
     selector: 5059197667603797935
     name: "janction-testnet-sepolia"
     network_type: testnet
+    deprecated: true
   682:
     selector: 6260932437388305511
     name: "private-testnet-obsidian"
@@ -119,6 +121,7 @@ selectors:
     selector: 1948510578179542068
     name: "bitcoin-testnet-bsquared-1"
     network_type: testnet
+    deprecated: true
   12325:
     selector: 3486622437121596122
     name: "ethereum-testnet-sepolia-arbitrum-1-l3x-1"
@@ -147,6 +150,7 @@ selectors:
     selector: 11059667695644972511
     name: "ethereum-testnet-goerli-polygon-zkevm-1"
     network_type: testnet
+    deprecated: true
   1908:
     selector: 4888058894222120000
     name: "bitcichain-testnet"
@@ -155,6 +159,7 @@ selectors:
     selector: 12168171414969487009
     name: "memento-testnet"
     network_type: testnet
+    deprecated: true
   2201:
     selector: 11793402411494852765
     name: "stable-testnet"
@@ -167,22 +172,27 @@ selectors:
     selector: 5990477251245693094
     name: "ethereum-testnet-sepolia-kroma-1"
     network_type: testnet
+    deprecated: true
   2442:
     selector: 1654667687261492630
     name: "ethereum-testnet-sepolia-polygon-zkevm-1"
     network_type: testnet
+    deprecated: true
   2522:
     selector: 8901520481741771655
     name: "ethereum-testnet-holesky-fraxtal-1"
     network_type: testnet
+    deprecated: true
   2810:
     selector: 8304510386741731151
     name: "ethereum-testnet-holesky-morph-1"
     network_type: testnet
+    deprecated: true
   3636:
     selector: 1467223411771711614
     name: "bitcoin-testnet-botanix"
     network_type: testnet
+    deprecated: true
   4002:
     selector: 4905564228793744293
     name: "fantom-testnet"
@@ -215,10 +225,12 @@ selectors:
     selector: 16088006396410204581
     name: "0g-testnet-newton"
     network_type: testnet
+    deprecated: true
   16601:
     selector: 2131427466778448014
     name: "0g-testnet-galileo"
     network_type: testnet
+    deprecated: true
   16602:
     selector: 6892437333620424805
     name: "0g-testnet-galileo-1"
@@ -239,6 +251,7 @@ selectors:
     selector: 3552045678561919002
     name: "celo-testnet-alfajores"
     network_type: testnet
+    deprecated: true
   48898:
     selector: 13781831279385219069
     name: "zircuit-testnet-garfield"
@@ -278,6 +291,7 @@ selectors:
     selector: 8999465244383784164
     name: "berachain-testnet-bartio"
     network_type: testnet
+    deprecated: true
   80069:
     selector: 7728255861635209484
     name: "berachain-testnet-bepolia"
@@ -286,6 +300,7 @@ selectors:
     selector: 2285225387454015855
     name: "zero-g-testnet-galileo"
     network_type: testnet
+    deprecated: true
   84531:
     selector: 5790810961207155433
     name: "ethereum-testnet-goerli-base-1"
@@ -358,6 +373,7 @@ selectors:
     selector: 3676916124122457866
     name: "treasure-testnet-topaz"
     network_type: testnet
+    deprecated: true
   31415926:
     selector: 7060342227814389000
     name: "filecoin-testnet"
@@ -378,6 +394,7 @@ selectors:
     selector: 2027362563942762617
     name: "ethereum-testnet-sepolia-blast-1"
     network_type: testnet
+    deprecated: true
   978657:
     selector: 10443705513486043421
     name: "ethereum-testnet-sepolia-arbitrum-1-treasure-1"
@@ -390,6 +407,7 @@ selectors:
     selector: 13116810400804392105
     name: "ronin-testnet-saigon"
     network_type: testnet
+    deprecated: true
   2023:
     selector: 3260900564719373474
     name: "private-testnet-granite"
@@ -422,6 +440,7 @@ selectors:
     selector: 3676871237479449268
     name: "sonic-testnet-blaze"
     network_type: testnet
+    deprecated: true
   998:
     selector: 4286062357653186312
     name: "hyperliquid-testnet"
@@ -438,6 +457,7 @@ selectors:
     selector: 7717148896336251131
     name: "ethereum-testnet-holesky"
     network_type: testnet
+    deprecated: true
   1301:
     selector: 14135854469784514356
     name: "ethereum-testnet-sepolia-unichain-1"
@@ -446,6 +466,7 @@ selectors:
     selector: 7248756420937879088
     name: "ethereum-testnet-holesky-taiko-1"
     network_type: testnet
+    deprecated: true
   161221135:
     selector: 14684575664602284776
     name: "plume-testnet"
@@ -469,6 +490,7 @@ selectors:
     selector: 2443239559770384419
     name: "megaeth-testnet"
     network_type: testnet
+    deprecated: true
   6343:
     selector: 18241817625092392675
     name: "megaeth-testnet-2"
@@ -481,6 +503,7 @@ selectors:
     selector: 10749384167430721561
     name: "mint-testnet"
     network_type: testnet
+    deprecated: true
   11124:
     selector: 16235373811196386733
     name: "abstract-testnet"
@@ -493,6 +516,7 @@ selectors:
     selector: 1910019406958449359
     name: "etherlink-testnet"
     network_type: testnet
+    deprecated: true
   1740:
     selector: 6286293440461807648
     name: "metal-testnet"
@@ -509,6 +533,7 @@ selectors:
     selector: 9090863410735740267
     name: "polygon-testnet-tatara"
     network_type: testnet
+    deprecated: true
   9746:
     selector: 3967220077692964309
     name: "plasma-testnet"
@@ -517,6 +542,7 @@ selectors:
     selector: 4012524741200567430
     name: "pharos-testnet"
     network_type: testnet
+    deprecated: true
   812242:
     selector: 7225665875429174318
     name: "codex-testnet"
@@ -577,6 +603,7 @@ selectors:
     selector: 3963528237232804922
     name: "tempo-testnet"
     network_type: testnet
+    deprecated: true
   42431:
     selector: 8457817439310187923
     name: "tempo-testnet-moderato"
@@ -597,6 +624,7 @@ selectors:
     selector: 1763698235108410440
     name: "sonic-testnet"
     network_type: testnet
+    deprecated: true
   424242:
     selector: 4489326297382772450
     name: "private-testnet-mica"
@@ -726,6 +754,7 @@ selectors:
     selector: 3719320017875267166
     name: "ethereum-mainnet-kroma-1"
     network_type: mainnet
+    deprecated: true
   259:
     selector: 8239338020728974000
     name: "neonlink-mainnet"
@@ -774,6 +803,7 @@ selectors:
     selector: 4348158687435793198
     name: "ethereum-mainnet-polygon-zkevm-1"
     network_type: mainnet
+    deprecated: true
   1111:
     selector: 5142893604156789321
     name: "wemix-mainnet"
@@ -786,6 +816,7 @@ selectors:
     selector: 5214452172935136222
     name: "treasure-mainnet"
     network_type: mainnet
+    deprecated: true
   12324:
     selector: 3162193654116181371
     name: "ethereum-mainnet-arbitrum-1-l3x-1"
@@ -870,6 +901,7 @@ selectors:
     selector: 6473245816409426016
     name: "memento-mainnet"
     network_type: mainnet
+    deprecated: true
   80094:
     selector: 1294465214383781161
     name: "berachain-mainnet"
@@ -990,6 +1022,7 @@ selectors:
     selector: 17164792800244661392
     name: "mint-mainnet"
     network_type: mainnet
+    deprecated: true
   42793:
     selector: 13624601974233774587
     name: "etherlink-mainnet"
@@ -1054,6 +1087,7 @@ selectors:
     selector: 9723842205701363942
     name: "everclear-mainnet"
     network_type: mainnet
+    deprecated: true
   36888:
     selector: 4829375610284793157
     name: "ab-mainnet"

--- a/selectors.yml
+++ b/selectors.yml
@@ -177,7 +177,6 @@ selectors:
     selector: 1654667687261492630
     name: "ethereum-testnet-sepolia-polygon-zkevm-1"
     network_type: testnet
-    deprecated: true
   2522:
     selector: 8901520481741771655
     name: "ethereum-testnet-holesky-fraxtal-1"
@@ -625,8 +624,7 @@ selectors:
   14601:
     selector: 1763698235108410440
     name: "sonic-testnet"
-    network_type: testnet
-    deprecated: true
+    network_type: testnet    
   424242:
     selector: 4489326297382772450
     name: "private-testnet-mica"
@@ -804,8 +802,7 @@ selectors:
   1101:
     selector: 4348158687435793198
     name: "ethereum-mainnet-polygon-zkevm-1"
-    network_type: mainnet
-    deprecated: true
+    network_type: mainnet    
   1111:
     selector: 5142893604156789321
     name: "wemix-mainnet"

--- a/selectors_test.go
+++ b/selectors_test.go
@@ -217,3 +217,17 @@ func TestIsMainnetChain(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDeprecated(t *testing.T) {
+	t.Run("known selector defaults to not deprecated", func(t *testing.T) {
+		deprecated, err := IsDeprecated(ETHEREUM_MAINNET.Selector)
+		require.NoError(t, err)
+		assert.False(t, deprecated)
+	})
+
+	t.Run("unknown selector returns error", func(t *testing.T) {
+		_, err := IsDeprecated(9999999999999999999)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown chain selector")
+	})
+}

--- a/test_extra_selectors.yml
+++ b/test_extra_selectors.yml
@@ -7,3 +7,8 @@ evm:
     selector: 9876543210987654321
     name: "overriding-existing-chain"
     network_type: testnet
+  91919191222:
+    selector: 1357913579135791357
+    name: "test-evm-chain-deprecated"
+    network_type: testnet
+    deprecated: true

--- a/types.go
+++ b/types.go
@@ -25,4 +25,6 @@ type ChainDetails struct {
 	ChainSelector uint64      `yaml:"selector"`
 	ChainName     string      `yaml:"name"`
 	NetworkType   NetworkType `yaml:"network_type"`
+	// Deprecated marks chains that have been sunset or superseded by a newer version.
+	Deprecated bool `yaml:"deprecated,omitempty"`
 }


### PR DESCRIPTION
Deprecated chains

1. 0g-testnet-galileo
2. 0g-testnet-newton
3. berachain-testnet-artio
4. berachain-testnet-bartio
5. bitcoin-testnet-botanix
6. bitcoin-testnet-bsquared-1
7. celo-testnet-alfajores
8. ethereum-mainnet-arbitrum-1-treasure-1
9. ethereum-mainnet-kroma-1
10. ethereum-mainnet-polygon-zkevm-1 ---> will deprecate this later, network still live
11. ethereum-testnet-goerli-polygon-zkevm-1
12. ethereum-testnet-holesky
13. ethereum-testnet-holesky-fraxtal-1
14. ethereum-testnet-holesky-morph-1
15. ethereum-testnet-holesky-taiko-1
16. ethereum-testnet-sepolia-arbitrum-1-treasure-1
17. ethereum-testnet-sepolia-blast-1
18. ethereum-testnet-sepolia-kroma-1
19. ethereum-testnet-sepolia-polygon-zkevm-1   ---> will deprecate this later, network still live
20. ethereum-testnet-sepolia-xlayer-1
21. etherlink-testnet
22. everclear-mainnet
23. janction-testnet-sepolia
24. megaeth-testnet
25. memento-mainnet
26. memento-testnet
27. mint-mainnet
28. mint-testnet
29. pharos-testnet
30. polygon-testnet-tatara
31. ronin-testnet-saigon
32. sonic-testnet
33. sonic-testnet-blaze
34. tempo-testnet
35. treasure-mainnet
36. treasure-testnet-topaz
37. zero-g-testnet-galileo