### PR TITLE
add GetChainDetailsByNetworkName function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ func main() {
     // Getting chain family based on selector
     family, err := GetSelectorFamily(2664363617261496610)
 
+    // Getting chain details based on network name
+    details, err := chainselectors.GetChainDetailsByNetworkName("ethereum-mainnet")
+
     // -------------------For EVM chains--------------------
 
     // Getting selector based on ChainId

--- a/selectors.go
+++ b/selectors.go
@@ -242,6 +242,48 @@ func GetChainNameFromSelector(selector uint64) (string, error) {
 	return chainInfo.ChainDetails.ChainName, nil
 }
 
+// GetChainDetailsByNetworkName returns chain details for the given network name.
+func GetChainDetailsByNetworkName(networkName string) (ChainDetails, error) {
+	if details, exist := getChainDetailsByNetworkName(networkName, evmChainIdToChainSelector); exist {
+		return details, nil
+	}
+	if details, exist := getChainDetailsByNetworkName(networkName, solanaChainIdToChainSelector); exist {
+		return details, nil
+	}
+	if details, exist := getChainDetailsByNetworkName(networkName, aptosSelectorsMap); exist {
+		return details, nil
+	}
+	if details, exist := getChainDetailsByNetworkName(networkName, suiSelectorsMap); exist {
+		return details, nil
+	}
+	if details, exist := getChainDetailsByNetworkName(networkName, tronSelectorsMap); exist {
+		return details, nil
+	}
+	if details, exist := getChainDetailsByNetworkName(networkName, tonSelectorsMap); exist {
+		return details, nil
+	}
+	if details, exist := getChainDetailsByNetworkName(networkName, starknetSelectorsMap); exist {
+		return details, nil
+	}
+	if details, exist := getChainDetailsByNetworkName(networkName, cantonChainsByChainId); exist {
+		return details, nil
+	}
+	if details, exist := getChainDetailsByNetworkName(networkName, stellarChainsByChainId); exist {
+		return details, nil
+	}
+
+	return ChainDetails{}, fmt.Errorf("chain details not found for network name %s", networkName)
+}
+
+func getChainDetailsByNetworkName[K comparable](networkName string, selectors map[K]ChainDetails) (ChainDetails, bool) {
+	for _, details := range selectors {
+		if details.ChainName == networkName {
+			return details, true
+		}
+	}
+	return ChainDetails{}, false
+}
+
 func GetChainDetailsByChainIDAndFamily(chainID string, family string) (ChainDetails, error) {
 	switch family {
 	case FamilyEVM:

--- a/selectors_test.go
+++ b/selectors_test.go
@@ -218,6 +218,40 @@ func TestIsMainnetChain(t *testing.T) {
 	}
 }
 
+func TestGetChainDetailsByNetworkName(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector uint64
+	}{
+		{name: "EVM", selector: ETHEREUM_MAINNET.Selector},
+		{name: "Solana", selector: SOLANA_MAINNET.Selector},
+		{name: "Aptos", selector: APTOS_MAINNET.Selector},
+		{name: "Sui", selector: SUI_MAINNET.Selector},
+		{name: "Tron", selector: TRON_MAINNET.Selector},
+		{name: "TON", selector: TON_MAINNET.Selector},
+		{name: "Starknet", selector: ETHEREUM_MAINNET_STARKNET_1.Selector},
+		{name: "Canton", selector: CANTON_MAINNET.Selector},
+		{name: "Stellar", selector: STELLAR_MAINNET.Selector},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected, err := GetChainDetails(tt.selector)
+			require.NoError(t, err)
+
+			got, err := GetChainDetailsByNetworkName(expected.ChainName)
+			require.NoError(t, err)
+			assert.Equal(t, expected, got)
+		})
+	}
+
+	t.Run("unknown network name returns error", func(t *testing.T) {
+		_, err := GetChainDetailsByNetworkName("unknown-network")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chain details not found for network name unknown-network")
+	})
+}
+
 func TestIsDeprecated(t *testing.T) {
 	t.Run("known selector defaults to not deprecated", func(t *testing.T) {
 		deprecated, err := IsDeprecated(ETHEREUM_MAINNET.Selector)


### PR DESCRIPTION
This pull request introduces a new utility function to retrieve blockchain chain details by network name, improving the usability of the chain selectors package. The main changes include the implementation of the `GetChainDetailsByNetworkName` function, corresponding helper logic, comprehensive unit tests, and an update to the documentation to demonstrate usage.

**New chain details lookup by network name:**

* Added the `GetChainDetailsByNetworkName` function to allow users to retrieve `ChainDetails` for a given network name, searching across all supported chain families. This provides a more flexible way to access chain information without needing to know the selector or chain ID.
* Implemented the internal helper `getChainDetailsByNetworkName` to iterate over chain maps and match by network name.

**Testing and documentation:**

* Added a comprehensive test `TestGetChainDetailsByNetworkName` to ensure correct behavior for all supported chains and to verify error handling for unknown network names.
* Updated the `README.md` with an example demonstrating how to use the new `GetChainDetailsByNetworkName` function.