### PR TITLE
feat: add sunsetAt datetime for chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ sunset, ok, err := chainselectors.GetSunsetDate(5009297550715157269)
 
 // Check whether the sunset date has already passed (i.e. the chain is offline as of now).
 isOffline, err := chainselectors.IsSunset(5009297550715157269)
+
+// The same helpers are available on the remote API (note the ctx argument):
+sunset, ok, err = chainsel.GetSunsetDate(ctx, 5009297550715157269)
+isOffline, err = chainsel.IsSunset(ctx, 5009297550715157269)
 ```
 
 > **Deprecation vs. sunset:** `Deprecated` marks a chain as discouraged (it may still be live).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,18 @@ deprecated, err := chainselectors.IsDeprecated(5009297550715157269)
 
 // Or with the remote API
 deprecated, err = chainsel.IsDeprecated(ctx, 5009297550715157269)
+
+// Get a deprecated chain's scheduled sunset date (when it goes/went offline).
+// ok is false when no sunset date is set.
+sunset, ok, err := chainselectors.GetSunsetDate(5009297550715157269)
+
+// Check whether the sunset date has already passed (i.e. the chain is offline as of now).
+isOffline, err := chainselectors.IsSunset(5009297550715157269)
 ```
+
+> **Deprecation vs. sunset:** `Deprecated` marks a chain as discouraged (it may still be live).
+> `SunsetAt` is the date it goes offline — a *future* date means it is still live, a *past* date
+> means it is offline. Empty means no sunset is scheduled.
 
 #### EVM-Specific Functions
 

--- a/all_selectors.yml
+++ b/all_selectors.yml
@@ -124,11 +124,13 @@ evm:
         name: mint-mainnet
         network_type: mainnet
         deprecated: true
+        sunset_at: "2026-04-17"
     195:
         selector: 2066098519157881736
         name: ethereum-testnet-sepolia-xlayer-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-09-15"
     196:
         selector: 3016212468291539606
         name: ethereum-mainnet-xlayer-1
@@ -150,6 +152,7 @@ evm:
         name: mind-mainnet
         network_type: mainnet
         deprecated: true
+        sunset_at: "2026-05-30"
     232:
         selector: 5608378062013572713
         name: lens-mainnet
@@ -175,6 +178,7 @@ evm:
         name: ethereum-mainnet-kroma-1
         network_type: mainnet
         deprecated: true
+        sunset_at: "2025-06-30"
     259:
         selector: 8239338020728974000
         name: neonlink-mainnet
@@ -183,6 +187,8 @@ evm:
         selector: 6802309497652714138
         name: ethereum-testnet-goerli-zksync-1
         network_type: testnet
+        deprecated: true
+        sunset_at: "2024-04-13"
     282:
         selector: 3842103497652714138
         name: cronos-testnet-zkevm-1
@@ -227,6 +233,8 @@ evm:
         selector: 2664363617261496610
         name: ethereum-testnet-goerli-optimism-1
         network_type: testnet
+        deprecated: true
+        sunset_at: "2024-04-13"
     462:
         selector: 7317911323415911000
         name: areon-testnet
@@ -252,6 +260,7 @@ evm:
         name: janction-testnet-sepolia
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-12-01"
     682:
         selector: 6260932437388305511
         name: private-testnet-obsidian
@@ -301,6 +310,7 @@ evm:
         name: ethereum-mainnet-polygon-zkevm-1
         network_type: mainnet
         deprecated: true
+        sunset_at: "2026-07-01"
     1111:
         selector: 5142893604156789321
         name: wemix-mainnet
@@ -322,6 +332,7 @@ evm:
         name: bitcoin-testnet-bsquared-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-12-01"
     1135:
         selector: 15293031020466096408
         name: lisk-mainnet
@@ -363,6 +374,7 @@ evm:
         name: ethereum-testnet-goerli-polygon-zkevm-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2024-04-13"
     1513:
         selector: 4237030917318060427
         name: story-testnet
@@ -376,6 +388,7 @@ evm:
         name: mint-testnet
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-04-17"
     1740:
         selector: 6286293440461807648
         name: metal-testnet
@@ -413,6 +426,7 @@ evm:
         name: ronin-testnet-saigon
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-02-05"
     2023:
         selector: 3260900564719373474
         name: private-testnet-granite
@@ -438,6 +452,7 @@ evm:
         name: memento-testnet
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-04-27"
     2201:
         selector: 11793402411494852765
         name: stable-testnet
@@ -455,6 +470,7 @@ evm:
         name: ethereum-testnet-sepolia-kroma-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-06-30"
     2391:
         selector: 9488606126177218005
         name: tac-testnet
@@ -468,6 +484,7 @@ evm:
         name: ethereum-testnet-holesky-fraxtal-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-10-17"
     2741:
         selector: 3577778157919314504
         name: abstract-mainnet
@@ -477,6 +494,7 @@ evm:
         name: ethereum-testnet-holesky-morph-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-10-21"
     2818:
         selector: 18164309074156128038
         name: morph-mainnet
@@ -494,11 +512,13 @@ evm:
         name: bitcoin-testnet-botanix
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-07-09"
     3637:
         selector: 4560701533377838164
         name: bitcoin-mainnet-botanix
         network_type: mainnet
         deprecated: true
+        sunset_at: "2026-07-09"
     3776:
         selector: 1540201334317828111
         name: ethereum-mainnet-astar-zkevm-1
@@ -539,6 +559,8 @@ evm:
         selector: 4168263376276232250
         name: ethereum-testnet-goerli-mantle-1
         network_type: testnet
+        deprecated: true
+        sunset_at: "2024-04-13"
     5003:
         selector: 8236463271206331221
         name: ethereum-testnet-sepolia-mantle-1
@@ -564,6 +586,7 @@ evm:
         name: megaeth-testnet
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-03-29"
     6343:
         selector: 18241817625092392675
         name: megaeth-testnet-2
@@ -653,11 +676,13 @@ evm:
         name: 0g-testnet-newton
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-04-29"
     16601:
         selector: 2131427466778448014
         name: 0g-testnet-galileo
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-04-29"
     16602:
         selector: 6892437333620424805
         name: 0g-testnet-galileo-1
@@ -671,11 +696,13 @@ evm:
         name: ethereum-testnet-holesky
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-09-30"
     25327:
         selector: 9723842205701363942
         name: everclear-mainnet
         network_type: mainnet
         deprecated: true
+        sunset_at: "2026-05-21"
     26888:
         selector: 7051849327615092843
         name: ab-testnet
@@ -725,6 +752,7 @@ evm:
         name: tempo-testnet
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-03-08"
     42431:
         selector: 8457817439310187923
         name: tempo-testnet-moderato
@@ -750,6 +778,7 @@ evm:
         name: celo-testnet-alfajores
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-09-30"
     45439:
         selector: 8446413392851542429
         name: private-testnet-opala
@@ -779,6 +808,7 @@ evm:
         name: memento-mainnet
         network_type: mainnet
         deprecated: true
+        sunset_at: "2026-04-27"
     53302:
         selector: 13694007683517087973
         name: superseed-testnet
@@ -788,6 +818,7 @@ evm:
         name: sonic-testnet-blaze
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-05-01"
     57073:
         selector: 3461204551265785888
         name: ethereum-mainnet-ink-1
@@ -796,6 +827,8 @@ evm:
         selector: 1355246678561316402
         name: ethereum-testnet-goerli-linea-1
         network_type: testnet
+        deprecated: true
+        sunset_at: "2024-04-13"
     59141:
         selector: 5719461335882077547
         name: ethereum-testnet-sepolia-linea-1
@@ -821,6 +854,7 @@ evm:
         name: treasure-mainnet
         network_type: mainnet
         deprecated: true
+        sunset_at: "2025-05-30"
     68414:
         selector: 12657445206920369324
         name: nexon-mainnet-henesys
@@ -846,16 +880,19 @@ evm:
         name: berachain-testnet-bartio
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-02-06"
     80085:
         selector: 12336603543561911511
         name: berachain-testnet-artio
         network_type: testnet
         deprecated: true
+        sunset_at: "2024-06-09"
     80087:
         selector: 2285225387454015855
         name: zero-g-testnet-galileo
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-04-29"
     80094:
         selector: 1294465214383781161
         name: berachain-mainnet
@@ -869,10 +906,13 @@ evm:
         name: ethereum-mainnet-blast-1
         network_type: mainnet
         deprecated: true
+        sunset_at: "2026-05-30"
     84531:
         selector: 5790810961207155433
         name: ethereum-testnet-goerli-base-1
         network_type: testnet
+        deprecated: true
+        sunset_at: "2024-04-13"
     84532:
         selector: 10344971235874465080
         name: ethereum-testnet-sepolia-base-1
@@ -910,11 +950,13 @@ evm:
         name: etherlink-testnet
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-03-13"
     129399:
         selector: 9090863410735740267
         name: polygon-testnet-tatara
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-08-20"
     167000:
         selector: 16468599424800719238
         name: ethereum-mainnet-taiko-1
@@ -924,6 +966,7 @@ evm:
         name: ethereum-testnet-holesky-taiko-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-09-30"
     167012:
         selector: 9873759436596923887
         name: ethereum-testnet-hoodi-taiko
@@ -937,6 +980,7 @@ evm:
         name: mind-testnet
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-05-30"
     200810:
         selector: 3789623672476206327
         name: bitcoin-testnet-bitlayer-1
@@ -957,6 +1001,8 @@ evm:
         selector: 6101244977088475029
         name: ethereum-testnet-goerli-arbitrum-1
         network_type: testnet
+        deprecated: true
+        sunset_at: "2024-04-13"
     421614:
         selector: 3478487238524512106
         name: ethereum-testnet-sepolia-arbitrum-1
@@ -998,6 +1044,7 @@ evm:
         name: pharos-testnet
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-10-27"
     688689:
         selector: 16098325658947243212
         name: pharos-atlantic-testnet
@@ -1047,16 +1094,19 @@ evm:
         name: ethereum-testnet-sepolia-arbitrum-1-treasure-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-05-09"
     978658:
         selector: 3676916124122457866
         name: treasure-testnet-topaz
         network_type: testnet
         deprecated: true
+        sunset_at: "2025-05-09"
     978670:
         selector: 1010349088906777999
         name: ethereum-mainnet-arbitrum-1-treasure-1
         network_type: mainnet
         deprecated: true
+        sunset_at: "2025-05-30"
     2019775:
         selector: 945045181441419236
         name: jovay-testnet
@@ -1098,11 +1148,13 @@ evm:
         name: corn-mainnet
         network_type: mainnet
         deprecated: true
+        sunset_at: "2026-06-30"
     21000001:
         selector: 1467427327723633929
         name: ethereum-testnet-sepolia-corn-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-06-30"
     31415926:
         selector: 7060342227814389000
         name: filecoin-testnet
@@ -1116,6 +1168,7 @@ evm:
         name: ethereum-testnet-sepolia-blast-1
         network_type: testnet
         deprecated: true
+        sunset_at: "2026-05-30"
     728126428:
         selector: 1546563616611573946
         name: tron-mainnet-evm

--- a/extra_selectors_test.go
+++ b/extra_selectors_test.go
@@ -246,6 +246,16 @@ func TestExtraSelectorsE2E(t *testing.T) {
 	deprecated, err = IsDeprecated(1234567890123456789)
 	assert.NoError(t, err)
 	assert.False(t, deprecated)
+
+	// SunsetAt from an extra-selectors file propagates through to GetSunsetDate / IsSunset.
+	// (Parsing behavior is covered by unit tests in selectors_test.go.)
+	sunsetDate, ok, err := GetSunsetDate(2468013579246801357)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, 2020, sunsetDate.Year())
+	sunset, err := IsSunset(2468013579246801357)
+	assert.NoError(t, err)
+	assert.True(t, sunset)
 }
 
 // Validates a custom provide file for formating errors. This can be used in external CI checks to ensure the file is valid.

--- a/extra_selectors_test.go
+++ b/extra_selectors_test.go
@@ -258,7 +258,7 @@ func TestExtraSelectorsE2E(t *testing.T) {
 	assert.True(t, sunset)
 }
 
-// Validates a custom provide file for formating errors. This can be used in external CI checks to ensure the file is valid.
+// Validates a custom provided file for formatting errors. This can be used in external CI checks to ensure the file is valid.
 func TestExtraSelectorsValidateCustomFile(t *testing.T) {
 	extraSelectorsFile := os.Getenv("EXTRA_SELECTORS_FILE")
 	if extraSelectorsFile == "" {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -480,6 +480,26 @@ func IsDeprecated(ctx context.Context, selector uint64, opts ...Option) (bool, e
 	return details.Deprecated, nil
 }
 
+// GetSunsetDate returns the chain's scheduled sunset date; ok is false when none is set.
+func GetSunsetDate(ctx context.Context, selector uint64, opts ...Option) (time.Time, bool, error) {
+	details, err := GetChainDetailsBySelector(ctx, selector, opts...)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+
+	return chain_selectors.ParseSunsetDate(details.SunsetAt)
+}
+
+// IsSunset reports whether the chain's sunset date has passed as of now.
+func IsSunset(ctx context.Context, selector uint64, opts ...Option) (bool, error) {
+	details, err := GetChainDetailsBySelector(ctx, selector, opts...)
+	if err != nil {
+		return false, err
+	}
+
+	return chain_selectors.SunsetPassed(details.SunsetAt, time.Now())
+}
+
 // ClearCache clears the remote data cache, forcing the next remote call to fetch fresh data
 func ClearCache() {
 	remoteCacheLock.Lock()

--- a/selectors.go
+++ b/selectors.go
@@ -443,8 +443,8 @@ func GetSunsetDate(selector uint64) (sunset time.Time, ok bool, err error) {
 	return ParseSunsetDate(chainDetails.SunsetAt)
 }
 
-// SunsetPassed reports whether sunsetAt is set and strictly before now.
-// It returns false when no sunset date is set.
+// SunsetPassed reports whether sunsetAt is set and has been reached as of now.
+// The sunset time itself counts as passed. It returns false when no sunset date is set.
 func SunsetPassed(sunsetAt string, now time.Time) (bool, error) {
 	sunset, ok, err := ParseSunsetDate(sunsetAt)
 	if err != nil {
@@ -454,7 +454,7 @@ func SunsetPassed(sunsetAt string, now time.Time) (bool, error) {
 		return false, nil
 	}
 
-	return now.After(sunset), nil
+	return !now.Before(sunset), nil
 }
 
 // IsSunset reports whether the chain's sunset date has passed as of now.

--- a/selectors.go
+++ b/selectors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"time"
 )
 
 type chainInfo struct {
@@ -414,6 +415,57 @@ func IsDeprecated(selector uint64) (bool, error) {
 	}
 
 	return chainDetails.Deprecated, nil
+}
+
+// ParseSunsetDate parses a ChainDetails.SunsetAt string (RFC 3339 or 2006-01-02).
+// ok is false and the time is zero when the value is empty.
+func ParseSunsetDate(sunsetAt string) (sunset time.Time, ok bool, err error) {
+	if sunsetAt == "" {
+		return time.Time{}, false, nil
+	}
+
+	for _, layout := range []string{time.RFC3339, "2006-01-02"} {
+		if t, err := time.Parse(layout, sunsetAt); err == nil {
+			return t, true, nil
+		}
+	}
+
+	return time.Time{}, false, fmt.Errorf("invalid sunset date %q", sunsetAt)
+}
+
+// GetSunsetDate returns the chain's scheduled sunset date; ok is false when none is set.
+func GetSunsetDate(selector uint64) (sunset time.Time, ok bool, err error) {
+	chainDetails, err := GetChainDetails(selector)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+
+	return ParseSunsetDate(chainDetails.SunsetAt)
+}
+
+// SunsetPassed reports whether sunsetAt is set and strictly before now.
+// It returns false when no sunset date is set.
+func SunsetPassed(sunsetAt string, now time.Time) (bool, error) {
+	sunset, ok, err := ParseSunsetDate(sunsetAt)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+
+	return now.After(sunset), nil
+}
+
+// IsSunset reports whether the chain's sunset date has passed as of now.
+// Returns false when no sunset date is set or it is still in the future.
+func IsSunset(selector uint64) (bool, error) {
+	chainDetails, err := GetChainDetails(selector)
+	if err != nil {
+		return false, err
+	}
+
+	return SunsetPassed(chainDetails.SunsetAt, time.Now())
 }
 
 func GetChainDetails(selector uint64) (ChainDetails, error) {

--- a/selectors.yml
+++ b/selectors.yml
@@ -48,6 +48,7 @@ selectors:
     name: "ethereum-testnet-sepolia-xlayer-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-09-15"
   240:
     selector: 16487132492576884721
     name: "cronos-zkevm-testnet-sepolia"
@@ -56,6 +57,8 @@ selectors:
     selector: 6802309497652714138
     name: "ethereum-testnet-goerli-zksync-1"
     network_type: testnet
+    deprecated: true
+    sunset_at: "2024-04-13"
   282:
     selector: 3842103497652714138
     name: "cronos-testnet-zkevm-1"
@@ -80,6 +83,8 @@ selectors:
     selector: 2664363617261496610
     name: "ethereum-testnet-goerli-optimism-1"
     network_type: testnet
+    deprecated: true
+    sunset_at: "2024-04-13"
   462:
     selector: 7317911323415911000
     name: "areon-testnet"
@@ -93,6 +98,7 @@ selectors:
     name: "janction-testnet-sepolia"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-12-01"
   682:
     selector: 6260932437388305511
     name: "private-testnet-obsidian"
@@ -122,6 +128,7 @@ selectors:
     name: "bitcoin-testnet-bsquared-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-12-01"
   12325:
     selector: 3486622437121596122
     name: "ethereum-testnet-sepolia-arbitrum-1-l3x-1"
@@ -151,6 +158,7 @@ selectors:
     name: "ethereum-testnet-goerli-polygon-zkevm-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2024-04-13"
   1908:
     selector: 4888058894222120000
     name: "bitcichain-testnet"
@@ -160,6 +168,7 @@ selectors:
     name: "memento-testnet"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-04-27"
   2201:
     selector: 11793402411494852765
     name: "stable-testnet"
@@ -173,6 +182,7 @@ selectors:
     name: "ethereum-testnet-sepolia-kroma-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-06-30"
   2442:
     selector: 1654667687261492630
     name: "ethereum-testnet-sepolia-polygon-zkevm-1"
@@ -182,16 +192,19 @@ selectors:
     name: "ethereum-testnet-holesky-fraxtal-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-10-17"
   2810:
     selector: 8304510386741731151
     name: "ethereum-testnet-holesky-morph-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-10-21"
   3636:
     selector: 1467223411771711614
     name: "bitcoin-testnet-botanix"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-07-09"
   4002:
     selector: 4905564228793744293
     name: "fantom-testnet"
@@ -204,6 +217,8 @@ selectors:
     selector: 4168263376276232250
     name: "ethereum-testnet-goerli-mantle-1"
     network_type: testnet
+    deprecated: true
+    sunset_at: "2024-04-13"
   5003:
     selector: 8236463271206331221
     name: "ethereum-testnet-sepolia-mantle-1"
@@ -225,11 +240,13 @@ selectors:
     name: "0g-testnet-newton"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-04-29"
   16601:
     selector: 2131427466778448014
     name: "0g-testnet-galileo"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-04-29"
   16602:
     selector: 6892437333620424805
     name: "0g-testnet-galileo-1"
@@ -251,6 +268,7 @@ selectors:
     name: "celo-testnet-alfajores"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-09-30"
   48898:
     selector: 13781831279385219069
     name: "zircuit-testnet-garfield"
@@ -263,6 +281,8 @@ selectors:
     selector: 1355246678561316402
     name: "ethereum-testnet-goerli-linea-1"
     network_type: testnet
+    deprecated: true
+    sunset_at: "2024-04-13"
   59141:
     selector: 5719461335882077547
     name: "ethereum-testnet-sepolia-linea-1"
@@ -287,11 +307,13 @@ selectors:
     name: "berachain-testnet-artio"
     network_type: testnet
     deprecated: true
+    sunset_at: "2024-06-09"
   80084:
     selector: 8999465244383784164
     name: "berachain-testnet-bartio"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-02-06"
   80069:
     selector: 7728255861635209484
     name: "berachain-testnet-bepolia"
@@ -301,10 +323,13 @@ selectors:
     name: "zero-g-testnet-galileo"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-04-29"
   84531:
     selector: 5790810961207155433
     name: "ethereum-testnet-goerli-base-1"
     network_type: testnet
+    deprecated: true
+    sunset_at: "2024-04-13"
   84532:
     selector: 10344971235874465080
     name: "ethereum-testnet-sepolia-base-1"
@@ -321,6 +346,8 @@ selectors:
     selector: 6101244977088475029
     name: "ethereum-testnet-goerli-arbitrum-1"
     network_type: testnet
+    deprecated: true
+    sunset_at: "2024-04-13"
   421614:
     selector: 3478487238524512106
     name: "ethereum-testnet-sepolia-arbitrum-1"
@@ -374,6 +401,7 @@ selectors:
     name: "treasure-testnet-topaz"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-05-09"
   31415926:
     selector: 7060342227814389000
     name: "filecoin-testnet"
@@ -391,16 +419,19 @@ selectors:
     name: "ethereum-testnet-sepolia-corn-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-06-30"
   168587773:
     selector: 2027362563942762617
     name: "ethereum-testnet-sepolia-blast-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-05-30"
   978657:
     selector: 10443705513486043421
     name: "ethereum-testnet-sepolia-arbitrum-1-treasure-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-05-09"
   1946:
     selector: 686603546605904534
     name: "ethereum-testnet-sepolia-soneium-1"
@@ -410,6 +441,7 @@ selectors:
     name: "ronin-testnet-saigon"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-02-05"
   2023:
     selector: 3260900564719373474
     name: "private-testnet-granite"
@@ -443,6 +475,7 @@ selectors:
     name: "sonic-testnet-blaze"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-05-01"
   998:
     selector: 4286062357653186312
     name: "hyperliquid-testnet"
@@ -460,6 +493,7 @@ selectors:
     name: "ethereum-testnet-holesky"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-09-30"
   1301:
     selector: 14135854469784514356
     name: "ethereum-testnet-sepolia-unichain-1"
@@ -469,6 +503,7 @@ selectors:
     name: "ethereum-testnet-holesky-taiko-1"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-09-30"
   161221135:
     selector: 14684575664602284776
     name: "plume-testnet"
@@ -486,6 +521,7 @@ selectors:
     name: "mind-testnet"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-05-30"
   1338:
     selector: 2181150070347029680
     network_type: testnet
@@ -494,6 +530,7 @@ selectors:
     name: "megaeth-testnet"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-03-29"
   6343:
     selector: 18241817625092392675
     name: "megaeth-testnet-2"
@@ -507,6 +544,7 @@ selectors:
     name: "mint-testnet"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-04-17"
   11124:
     selector: 16235373811196386733
     name: "abstract-testnet"
@@ -520,6 +558,7 @@ selectors:
     name: "etherlink-testnet"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-03-13"
   1740:
     selector: 6286293440461807648
     name: "metal-testnet"
@@ -537,6 +576,7 @@ selectors:
     name: "polygon-testnet-tatara"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-08-20"
   9746:
     selector: 3967220077692964309
     name: "plasma-testnet"
@@ -546,6 +586,7 @@ selectors:
     name: "pharos-testnet"
     network_type: testnet
     deprecated: true
+    sunset_at: "2025-10-27"
   812242:
     selector: 7225665875429174318
     name: "codex-testnet"
@@ -607,6 +648,7 @@ selectors:
     name: "tempo-testnet"
     network_type: testnet
     deprecated: true
+    sunset_at: "2026-03-08"
   42431:
     selector: 8457817439310187923
     name: "tempo-testnet-moderato"
@@ -774,6 +816,7 @@ selectors:
     name: "ethereum-mainnet-kroma-1"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2025-06-30"
   259:
     selector: 8239338020728974000
     name: "neonlink-mainnet"
@@ -823,6 +866,7 @@ selectors:
     name: "ethereum-mainnet-polygon-zkevm-1"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2026-07-01"
   1111:
     selector: 5142893604156789321
     name: "wemix-mainnet"
@@ -836,6 +880,7 @@ selectors:
     name: "treasure-mainnet"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2025-05-30"
   12324:
     selector: 3162193654116181371
     name: "ethereum-mainnet-arbitrum-1-l3x-1"
@@ -869,6 +914,7 @@ selectors:
     name: "bitcoin-mainnet-botanix"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2026-07-09"
   3776:
     selector: 1540201334317828111
     name: "ethereum-mainnet-astar-zkevm-1"
@@ -922,6 +968,7 @@ selectors:
     name: "memento-mainnet"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2026-04-27"
   80094:
     selector: 1294465214383781161
     name: "berachain-mainnet"
@@ -947,6 +994,7 @@ selectors:
     name: "ethereum-mainnet-blast-1"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2026-05-30"
   534352:
     selector: 13204309965629103672
     name: "ethereum-mainnet-scroll-1"
@@ -964,6 +1012,7 @@ selectors:
     name: "ethereum-mainnet-arbitrum-1-treasure-1"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2025-05-30"
   48900:
     selector: 17198166215261833993
     name: "ethereum-mainnet-zircuit-1"
@@ -1009,6 +1058,7 @@ selectors:
     name: "corn-mainnet"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2026-06-30"
   2818:
     selector: 18164309074156128038
     name: "morph-mainnet"
@@ -1022,6 +1072,7 @@ selectors:
     name: "mind-mainnet"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2026-05-30"
   728126428:
     selector: 1546563616611573946
     name: "tron-mainnet-evm"
@@ -1047,6 +1098,7 @@ selectors:
     name: "mint-mainnet"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2026-04-17"
   42793:
     selector: 13624601974233774587
     name: "etherlink-mainnet"
@@ -1112,6 +1164,7 @@ selectors:
     name: "everclear-mainnet"
     network_type: mainnet
     deprecated: true
+    sunset_at: "2026-05-21"
   36888:
     selector: 4829375610284793157
     name: "ab-mainnet"

--- a/selectors_test.go
+++ b/selectors_test.go
@@ -306,6 +306,7 @@ func TestSunsetPassed(t *testing.T) {
 		wantErr    bool
 	}{
 		{"past date is dead", "2020-01-01T00:00:00Z", true, false},
+		{"exact sunset time is dead", "2025-06-01T00:00:00Z", true, false},
 		{"future date is live", "2999-01-01", false, false},
 		{"empty is not sunset", "", false, false},
 		{"invalid", "not-a-date", false, true},

--- a/selectors_test.go
+++ b/selectors_test.go
@@ -2,6 +2,7 @@ package chain_selectors
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -264,4 +265,133 @@ func TestIsDeprecated(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown chain selector")
 	})
+}
+
+// Parsing of both accepted formats plus empty/invalid.
+func TestParseSunsetDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantOK   bool
+		wantTime time.Time
+		wantErr  bool
+	}{
+		{"RFC 3339 datetime", "2020-01-02T03:04:05Z", true, time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC), false},
+		{"date only", "2999-01-01", true, time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC), false},
+		{"empty is not set", "", false, time.Time{}, false},
+		{"invalid", "not-a-date", false, time.Time{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, ok, err := ParseSunsetDate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid sunset date")
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantTime, ts)
+		})
+	}
+}
+
+// Sunset liveness: future = live, past = dead, unset = never dead.
+func TestSunsetPassed(t *testing.T) {
+	now := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		sunsetAt   string
+		wantPassed bool
+		wantErr    bool
+	}{
+		{"past date is dead", "2020-01-01T00:00:00Z", true, false},
+		{"future date is live", "2999-01-01", false, false},
+		{"empty is not sunset", "", false, false},
+		{"invalid", "not-a-date", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			passed, err := SunsetPassed(tt.sunsetAt, now)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid sunset date")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPassed, passed)
+		})
+	}
+}
+
+// Registry wiring and error propagation for GetSunsetDate / IsSunset.
+// (Past-date sunset is verified end-to-end in TestExtraSelectorsE2E.)
+func TestSunsetAccessors(t *testing.T) {
+	tests := []struct {
+		name        string
+		selector    uint64
+		wantHasDate bool
+		wantSunset  bool
+		wantErr     bool
+	}{
+		{"chain without sunset date", ETHEREUM_MAINNET.Selector, false, false, false},
+		{"unknown selector", 9999999999999999999, false, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok, err := GetSunsetDate(tt.selector)
+			sunset, serr := IsSunset(tt.selector)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Error(t, serr)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, serr)
+			assert.Equal(t, tt.wantHasDate, ok)
+			assert.Equal(t, tt.wantSunset, sunset)
+		})
+	}
+}
+
+// Every configured sunset_at must parse, so a malformed date fails CI and can't be merged.
+func TestAllSunsetDatesValid(t *testing.T) {
+	check := func(name, sunsetAt string) {
+		if sunsetAt == "" {
+			return
+		}
+		_, ok, err := ParseSunsetDate(sunsetAt)
+		require.NoErrorf(t, err, "chain %q has invalid sunset_at %q", name, sunsetAt)
+		assert.Truef(t, ok, "chain %q sunset_at %q parsed but reported not set", name, sunsetAt)
+	}
+	checkAll := func(selectors []ChainDetails) {
+		for _, d := range selectors {
+			check(d.ChainName, d.SunsetAt)
+		}
+	}
+	values := func(m map[uint64]ChainDetails) []ChainDetails {
+		out := make([]ChainDetails, 0, len(m))
+		for _, d := range m {
+			out = append(out, d)
+		}
+		return out
+	}
+	stringKeyed := func(m map[string]ChainDetails) []ChainDetails {
+		out := make([]ChainDetails, 0, len(m))
+		for _, d := range m {
+			out = append(out, d)
+		}
+		return out
+	}
+	checkAll(values(evmChainIdToChainSelector))
+	checkAll(stringKeyed(solanaChainIdToChainSelector))
+	checkAll(values(aptosSelectorsMap))
+	checkAll(values(suiSelectorsMap))
+	checkAll(values(tronSelectorsMap))
+	checkAll(stringKeyed(starknetSelectorsMap))
+	checkAll(stringKeyed(cantonChainsByChainId))
+	checkAll(stringKeyed(stellarChainsByChainId))
+	for _, d := range tonSelectorsMap {
+		check(d.ChainName, d.SunsetAt)
+	}
 }

--- a/test_extra_selectors.yml
+++ b/test_extra_selectors.yml
@@ -12,3 +12,8 @@ evm:
     name: "test-evm-chain-deprecated"
     network_type: testnet
     deprecated: true
+  92929292333:
+    selector: 2468013579246801357
+    name: "test-evm-chain-sunset-past"
+    network_type: testnet
+    sunset_at: "2020-01-01T00:00:00Z"

--- a/types.go
+++ b/types.go
@@ -25,7 +25,8 @@ type ChainDetails struct {
 	ChainSelector uint64      `yaml:"selector"`
 	ChainName     string      `yaml:"name"`
 	NetworkType   NetworkType `yaml:"network_type"`
-	// Deprecated marks chains that have been sunset or superseded by a newer version.
+	// Deprecated marks chains that are discouraged or superseded by a newer version.
+	// A deprecated chain may still be live; see SunsetAt for when it goes offline.
 	Deprecated bool `yaml:"deprecated,omitempty"`
 	// SunsetAt is when the chain is (or was) scheduled to go offline, as an RFC 3339
 	// datetime or "2006-01-02" date. Empty means no sunset is set.

--- a/types.go
+++ b/types.go
@@ -27,4 +27,7 @@ type ChainDetails struct {
 	NetworkType   NetworkType `yaml:"network_type"`
 	// Deprecated marks chains that have been sunset or superseded by a newer version.
 	Deprecated bool `yaml:"deprecated,omitempty"`
+	// SunsetAt is when the chain is (or was) scheduled to go offline, as an RFC 3339
+	// datetime or "2006-01-02" date. Empty means no sunset is set.
+	SunsetAt string `yaml:"sunset_at,omitempty"`
 }


### PR DESCRIPTION
Add sunset dates for deprecated chains

> **Deprecation vs. sunset:** `Deprecated` marks a chain as discouraged (it may still be live).
> `SunsetAt` is the date it goes offline — a *future* date means it is still live, a *past* date
> means it is offline. Empty means no sunset is scheduled.

## Summary

- Introduces a `sunset_at` field to track when a chain went (or will go) offline, and backfills it for deprecated chains using researched shutdown dates. 
- marks all remaining Goerli-based testnets as deprecated. 
- Previously we only had a boolean deprecated flag with no notion of when — this enables downstream systems (e.g. Insights, alerting) to build advance-warning logic and distinguish "deprecated" from "actually offline".

## Changes

**New API (types.go, selectors.go)**
- `ChainDetails.SunsetAt` — optional RFC 3339 datetime or 2006-01-02 date; empty means no sunset set. Fully backward compatible (omitempty).
- `GetSunsetDate(selector) (time.Time, bool, error)` — returns the parsed date; ok is false when none is set.
- `IsSunset(selector) (bool, error)` — reports whether the sunset date has passed as of now.
- `IsDeprecated` is unchanged.

**Data (selectors.yml, regenerated all_selectors.yml)**
- Backfilled sunset_at on 47 deprecated chains with dates sourced from official announcements / block explorers.
- Marked 6 Goerli testnets (goerli-{arbitrum,base,linea,mantle,optimism,zksync}-1) as deprecated with Goerli's sunset date (2024-04-13).
- All Holesky chains carry 2025-09-30 (Ethereum Holesky sunset), except holesky-fraxtal-1 (2025-10-17) and holesky-morph-1 (2025-10-21), which keep their own confirmed shutdown dates.
